### PR TITLE
Fix type validation: Allow values to be more than one type

### DIFF
--- a/lib/committee/param_validator.rb
+++ b/lib/committee/param_validator.rb
@@ -79,24 +79,22 @@ module Committee
       end
     end
 
-    def check_type(types, value, key)
-      type = case value
+    def check_type(allowed_types, value, key)
+      types = case value
       when NilClass
-        "null"
+        ["null"]
       when TrueClass, FalseClass
-        "boolean"
-      when Bignum, Fixnum, Float
-        "number"
+        ["boolean"]
+      when Bignum, Fixnum
+        ["integer", "number"]
+      when Float
+        ["number"]
       when String
-        "string"
-      when Hash
-        "object"
-      when Array
-        "array"
+        ["string"]
       else
-        "unknown"
+        ["unknown"]
       end
-      types.include?(type)
+      !(allowed_types & types).empty?
     end
 
     def check_type!(types, value, key)

--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -81,26 +81,24 @@ module Committee
       end
     end
 
-    def check_type!(types, value, path)
-      type = case value
+    def check_type!(allowed_types, value, path)
+      types = case value
       when NilClass
-        "null"
+        ["null"]
       when TrueClass, FalseClass
-        "boolean"
-      when Bignum, Fixnum, Float
-        "number"
+        ["boolean"]
+      when Bignum, Fixnum
+        ["integer", "number"]
+      when Float
+        ["number"]
       when String
-        "string"
-      when Hash
-        "object"
-      when Array
-        "array"
+        ["string"]
       else
-        "unknown"
+        ["unknown"]
       end
-      unless types.include?(type)
+      if (allowed_types & types).empty?
         raise InvalidResponse,
-          %{Invalid type at "#{path.join(":")}": expected #{value} to be #{types} (was: #{type}).}
+          %{Invalid type at "#{path.join(":")}": expected #{value} to be #{allowed_types} (was: #{types}).}
       end
     end
 

--- a/test/response_validator_test.rb
+++ b/test/response_validator_test.rb
@@ -44,7 +44,7 @@ describe Committee::ResponseValidator do
   it "detects mismatched types" do
     @data.merge!("maintenance" => "not-bool")
     e = assert_raises(Committee::InvalidResponse) { call }
-    message = %{Invalid type at "maintenance": expected not-bool to be ["boolean"] (was: string).}
+    message = %{Invalid type at "maintenance": expected not-bool to be ["boolean"] (was: ["string"]).}
     assert_equal message, e.message
   end
 


### PR DESCRIPTION
Values like `1` should count as both an "integer" and a "number" according to the [primitive type definition of JSON schema](http://json-schema.org/latest/json-schema-core.html#anchor8). This pull allows that to happen.
