### PR TITLE
Allow tests to take a `schema_url_prefix`

### DIFF
--- a/lib/committee/router.rb
+++ b/lib/committee/router.rb
@@ -4,7 +4,8 @@ module Committee
       @routes = build_routes(schema)
     end
 
-    def routes?(method, path)
+    def routes?(method, path, options = {})
+      path = options[:prefix] + path if options[:prefix]
       if method_routes = @routes[method]
         method_routes.each do |pattern, link, schema|
           if path =~ pattern
@@ -15,8 +16,8 @@ module Committee
       [nil, nil]
     end
 
-    def routes_request?(request)
-      routes?(request.request_method, request.path_info)
+    def routes_request?(request, options = {})
+      routes?(request.request_method, request.path_info, options)
     end
 
     private

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -6,7 +6,8 @@ module Committee::Test
       @schema ||= Committee::Schema.new(File.read(schema_path))
       @router ||= Committee::Router.new(@schema)
 
-      link_schema, type_schema = @router.routes_request?(last_request)
+      link_schema, type_schema =
+        @router.routes_request?(last_request, prefix: schema_url_prefix)
 
       unless link_schema
         response = "`#{last_request.request_method} #{last_request.path_info}` undefined in schema."
@@ -31,6 +32,10 @@ module Committee::Test
 
     def schema_path
       raise "Please override #schema_path."
+    end
+
+    def schema_url_prefix
+      nil
     end
   end
 end

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -14,4 +14,9 @@ describe Committee::Router do
   it "builds routes with parameters" do
     assert @router.routes?("GET", "/apps/123")
   end
+
+  it "takes a prefix" do
+    # this is a sociopathic example
+    assert @router.routes?("GET", "123", prefix: "/apps")
+  end
 end


### PR DESCRIPTION
This is for cases where a schema isn't mapped at a URL root. We should 
probably get this working for the middlewares as well, but they're a little
more flexible in that they can usually be mounted from within a
`Rack::URLMap` and not see a path change.
