### PR TITLE
Add `allow_extra` option for `Committee::Middleware::RequestValidation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ use Committee::Middleware::RequestValidation, schema: File.read(...)
 
 This piece of middleware validates the parameters of incoming requests to make sure that they're formatted according to the constraints imposed by a particular schema.
 
+Options:
+
+* `allow_extra`: Doesn't raise an error when extra incoming parameters are found.
+* `prefix`: Mounts the middleware respond at a configured prefix.
+
 Some examples of use:
 
 ``` bash
@@ -95,6 +100,10 @@ use Committee::Middleware::ResponseValidation, schema: File.read(...)
 ```
 
 This piece of middleware validates the contents of the response received from up the stack for any route that matches the JSON Schema.
+
+Options:
+
+* `prefix`: Mounts the middleware respond at a configured prefix.
 
 Given a simple Sinatra app that responds for an endpoint in an incomplete fashion:
 

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -2,6 +2,7 @@ module Committee::Middleware
   class RequestValidation < Base
     def initialize(app, options={})
       super
+      @allow_extra = options[:allow_extra]
       @prefix = options[:prefix]
     end
 
@@ -10,7 +11,12 @@ module Committee::Middleware
       env[@params_key] = Committee::RequestUnpacker.new(request).call
       link, _ = @router.routes_request?(request, prefix: @prefix)
       if link
-        Committee::ParamValidator.new(env[@params_key], @schema, link).call
+        Committee::ParamValidator.new(
+          env[@params_key],
+          @schema,
+          link,
+          allow_extra: @allow_extra
+        ).call
       end
       @app.call(env)
     rescue Committee::BadRequest

--- a/lib/committee/param_validator.rb
+++ b/lib/committee/param_validator.rb
@@ -2,15 +2,16 @@ module Committee
   class ParamValidator
     include Validation
 
-    def initialize(params, schema, link_schema)
+    def initialize(params, schema, link_schema, options = {})
       @params = params
       @schema = schema
       @link_schema = link_schema
+      @allow_extra = options[:allow_extra]
     end
 
     def call
       detect_missing!
-      detect_extra!
+      detect_extra! if !@allow_extra
       check_data!
     end
 

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -46,6 +46,18 @@ describe Committee::Middleware::RequestValidation do
     assert_match /unknown params/i, last_response.body
   end
 
+  it "doesn't error on an extra parameter with allow_extra" do
+    @app = new_rack_app(allow_extra: true)
+    params = {
+      "app" => "heroku-api",
+      "cloud" => "production",
+      "recipient" => "owner@heroku.com",
+    }
+    header "Content-Type", "application/json"
+    post "/account/app-transfers", MultiJson.encode(params)
+    assert_equal 200, last_response.status
+  end
+
   it "rescues JSON errors" do
     @app = new_rack_app
     header "Content-Type", "application/json"


### PR DESCRIPTION
This changes the middleware's behavior so that it doesn't error when extra
incoming parameters are detected.
