### PR TITLE
Inspect value on mismatched type

### DIFF
--- a/lib/committee/validation.rb
+++ b/lib/committee/validation.rb
@@ -32,9 +32,9 @@ module Committee
 
       description = case identifier
       when String
-        %{Invalid type for key "#{identifier}": expected #{value} to be #{allowed_types}.}
+        %{Invalid type for key "#{identifier}": expected #{value.inspect} to be #{allowed_types}.}
       when Array
-        %{Invalid type at "#{identifier.join(":")}": expected #{value} to be #{allowed_types}.}
+        %{Invalid type at "#{identifier.join(":")}": expected #{value.inspect} to be #{allowed_types}.}
       end
 
       raise InvalidType, description

--- a/test/response_validator_test.rb
+++ b/test/response_validator_test.rb
@@ -51,7 +51,7 @@ describe Committee::ResponseValidator do
   it "detects mismatched types" do
     @data.merge!("maintenance" => "not-bool")
     e = assert_raises(Committee::InvalidType) { call }
-    message = %{Invalid type at "maintenance": expected not-bool to be ["boolean"].}
+    message = %{Invalid type at "maintenance": expected "not-bool" to be ["boolean"].}
     assert_equal message, e.message
   end
 


### PR DESCRIPTION
This should make it a bit easier to differentiate an empty string from a value.
