### PR TITLE
Fix Travis: install gems required for specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 before_script:
-  - gem build committee.gemspec
-  - gem install --dev committee-*.gem
+  - gem install json_schema minitest multi_json rack rack-test rr

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -15,8 +15,4 @@ Gem::Specification.new do |s|
   s.add_dependency "json_schema", "> 0.0"
   s.add_dependency "multi_json", "> 0.0"
   s.add_dependency "rack", "> 0.0"
-
-  s.add_development_dependency "minitest"
-  s.add_development_dependency "rack-test"
-  s.add_development_dependency "rr"
 end


### PR DESCRIPTION
Add a `.travis.yml` with before scripting relevant for fixing the Travis build.
