### PR TITLE
Add option that allows exceptions to be raised from middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This piece of middleware validates the parameters of incoming requests to make s
 Options:
 
 * `prefix`: Mounts the middleware respond at a configured prefix.
-* `strict`: Puts the middleware into strict mode, meaning that paths which are not defined in the schema will be responded to with a 404 instead of being run.
+* `raise`: Raise an exception on error instead of responding with a generic error body (defaults to `false`).
+* `strict`: Puts the middleware into strict mode, meaning that paths which are not defined in the schema will be responded to with a 404 instead of being run (default to `false`).
 
 Some examples of use:
 
@@ -104,6 +105,7 @@ This piece of middleware validates the contents of the response received from up
 Options:
 
 * `prefix`: Mounts the middleware respond at a configured prefix.
+* `raise`: Raise an exception on error instead of responding with a generic error body (defaults to `false`).
 
 Given a simple Sinatra app that responds for an endpoint in an incomplete fashion:
 

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -3,6 +3,7 @@ module Committee::Middleware
     def initialize(app, options={})
       super
       @prefix = options[:prefix]
+      @raise  = options[:raise]
       @strict = options[:strict]
 
       # deprecated
@@ -24,11 +25,14 @@ module Committee::Middleware
         end
       end
     rescue Committee::BadRequest, Committee::InvalidRequest
+      raise if @raise
       render_error(400, :bad_request, $!.message)
     rescue Committee::NotFound
+      raise if @raise
       render_error(404, :not_found,
         "That request method and path combination isn't defined.")
     rescue MultiJson::LoadError
+      raise Committee::InvalidRequest if @raise
       render_error(400, :bad_request, "Request body wasn't valid JSON.")
     end
   end

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -3,6 +3,7 @@ module Committee::Middleware
     def initialize(app, options={})
       super
       @prefix = options[:prefix]
+      @raise  = options[:raise]
     end
 
     def call(env)
@@ -15,8 +16,10 @@ module Committee::Middleware
       end
       [status, headers, response]
     rescue Committee::InvalidResponse
+      raise if @raise
       render_error(500, :invalid_response, $!.message)
     rescue MultiJson::LoadError
+      raise Commitee::InvalidResponse if @raise
       render_error(500, :invalid_response, "Response wasn't valid JSON.")
     end
   end

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -69,6 +69,14 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 404, last_response.status
   end
 
+  it "optionally raises an error" do
+    @app = new_rack_app(raise: true)
+    header "Content-Type", "application/json"
+    assert_raises(Committee::InvalidRequest) do
+      post "/apps", "{x:y}"
+    end
+  end
+
   private
 
   def new_rack_app(options = {})

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -41,6 +41,13 @@ describe Committee::Middleware::ResponseValidation do
     assert_equal 200, last_response.status
   end
 
+  it "rescues JSON errors" do
+    @app = new_rack_app("[{x:y}]", {}, raise: true)
+    assert(Committee::InvalidResponse) do
+      get "/apps"
+    end
+  end
+
   private
 
   def new_rack_app(response, headers = {}, options = {})


### PR DESCRIPTION
Direct responses may not be desirable in cases of larger applications that
need more fine-grain control. Add an option that allows exceptions to be
raised so that they can be caught and responded to further up the middleware
stack.
