### PR TITLE
Rack response bodies are only guaranteed to provide #each.

### DIFF
--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -10,8 +10,11 @@ module Committee::Middleware
       status, headers, response = @app.call(env)
       request = Rack::Request.new(env)
       if link = @router.routes_request?(request, prefix: @prefix)
-        str = response.reduce("") { |str, s| str << s }
-        data = MultiJson.decode(str)
+        full_body = ""
+        response.each do |chunk|
+          full_body << chunk
+        end
+        data = MultiJson.decode(full_body)
         Committee::ResponseValidator.new(link).call(headers, data)
       end
       [status, headers, response]


### PR DESCRIPTION
According to the [rack spec](http://rubydoc.info/github/rack/rack/master/file/SPEC#The_Body), the response body is only required to respond to `#each`.

This fix is required to use Committee as a middleware in Rails as responses come back as `ActionDispatch::Response` which does not implement `#reduce`.
