### PR TITLE
Don't error from within `RequestUnpacker`; return empty hash instead

### DIFF
--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -27,7 +27,7 @@ module Committee
         # PUT or PATCH too. Silly Rack.
         indifferent_params(@request.POST)
       else
-        raise BadRequest, "Unsupported Content-Type: #{@request.content_type}."
+        {}
       end
     end
 

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -59,8 +59,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new('{"x":"y"}'),
     }
     request = Rack::Request.new(env)
-    assert_raises(Committee::BadRequest) do
-      Committee::RequestUnpacker.new(request).call
-    end
+    params = Committee::RequestUnpacker.new(request).call
+    assert_equal({}, params)
   end
 end


### PR DESCRIPTION
Provides an alternative solution to the problem described #40.
