### PR TITLE
ResponseValidation middleware takes validate_errors flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Options:
 
 * `prefix`: Mounts the middleware respond at a configured prefix.
 * `raise`: Raise an exception on error instead of responding with a generic error body (defaults to `false`).
+* `validate_errors`: Also validate non-2xx responses (defaults to `false`).
 
 Given a simple Sinatra app that responds for an endpoint in an incomplete fashion:
 

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -2,13 +2,14 @@ module Committee::Middleware
   class ResponseValidation < Base
     def initialize(app, options={})
       super
-      @raise  = options[:raise]
+      @raise = options[:raise]
+      @validate_errors = options[:validate_errors]
     end
 
     def handle(request)
       status, headers, response = @app.call(request.env)
 
-      if link = @router.find_request_link(request)
+      if validate?(status) && link = @router.find_request_link(request)
         full_body = ""
         response.each do |chunk|
           full_body << chunk
@@ -16,6 +17,7 @@ module Committee::Middleware
         data = MultiJson.decode(full_body)
         Committee::ResponseValidator.new(link).call(headers, data)
       end
+
       [status, headers, response]
     rescue Committee::InvalidResponse
       raise if @raise
@@ -23,6 +25,10 @@ module Committee::Middleware
     rescue MultiJson::LoadError
       raise Committee::InvalidResponse if @raise
       render_error(500, :invalid_response, "Response wasn't valid JSON.")
+    end
+
+    def validate?(status)
+      @validate_errors || (200...300).include?(status)
     end
   end
 end

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -20,6 +20,12 @@ describe Committee::Middleware::ResponseValidation do
     assert_match /valid JSON/i, last_response.body
   end
 
+  it "ignores a non-2xx invalid response" do
+    @app = new_rack_app("[]", {}, app_status: 404)
+    get "/apps"
+    assert_equal 404, last_response.status
+  end
+
   it "rescues JSON errors" do
     @app = new_rack_app("[{x:y}]")
     get "/apps"
@@ -60,7 +66,7 @@ describe Committee::Middleware::ResponseValidation do
     Rack::Builder.new {
       use Committee::Middleware::ResponseValidation, options
       run lambda { |_|
-        [200, headers, [response]]
+        [options.fetch(:app_status, 200), headers, [response]]
       }
     }
   end


### PR DESCRIPTION
Ref #42

Add a `validate_errors` flag to `ResponseValidation` middleware, defaulting to `false`.
