### PR TITLE
Don't validate `Content-Type` when request body is empty

### DIFF
--- a/lib/committee/request_validator.rb
+++ b/lib/committee/request_validator.rb
@@ -27,6 +27,9 @@ module Committee
     end
 
     def empty_request?(request)
+      # small optimization: assume GET and DELETE don't have bodies
+      return true if request.get? || request.delete?
+
       data = request.body.read
       request.body.rewind
       data.empty?

--- a/test/request_validator_test.rb
+++ b/test/request_validator_test.rb
@@ -10,8 +10,9 @@ describe Committee::RequestValidator do
     # POST /apps/:id
     @link = @link = @schema.properties["app"].links[0]
     @request = Rack::Request.new({
-      "CONTENT_TYPE" => "application/json",
-      "rack.input"   => StringIO.new("{}"),
+      "CONTENT_TYPE"   => "application/json",
+      "rack.input"     => StringIO.new("{}"),
+      "REQUEST_METHOD" => "POST"
     })
   end
 


### PR DESCRIPTION
This makes validation on incoming requests a little more forgiving.

Fixes #45.

/cc @dpiddy
