### PR TITLE
Make unpacking form parameters optional

### DIFF
--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -2,15 +2,19 @@ module Committee::Middleware
   class RequestValidation < Base
     def initialize(app, options={})
       super
-      @raise  = options[:raise]
-      @strict = options[:strict]
+      @allow_form_params = options.fetch(:allow_form_params, true)
+      @raise             = options[:raise]
+      @strict            = options[:strict]
 
       # deprecated
       @allow_extra = options[:allow_extra]
     end
 
     def handle(request)
-      request.env[@params_key] = Committee::RequestUnpacker.new(request).call
+      request.env[@params_key] = Committee::RequestUnpacker.new(
+        request,
+        allow_form_params: @allow_form_params
+      ).call
 
       if link = @router.find_request_link(request)
         validator = Committee::RequestValidator.new(link)

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -1,7 +1,9 @@
 module Committee
   class RequestUnpacker
-    def initialize(request)
+    def initialize(request, options={})
       @request = request
+
+      @allow_form_params = options[:allow_form_params]
     end
 
     def call
@@ -22,7 +24,7 @@ module Committee
         else
           {}
         end
-      elsif @request.content_type == "application/x-www-form-urlencoded"
+      elsif @allow_form_params && @request.content_type == "application/x-www-form-urlencoded"
         # Actually, POST means anything in the request body, could be from
         # PUT or PATCH too. Silly Rack.
         indifferent_params(@request.POST)

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -32,13 +32,23 @@ describe Committee::RequestUnpacker do
     assert_equal({}, params)
   end
 
-  it "unpacks params on Content-Type: application/x-www-form-urlencoded" do
+  it "doesn't unpack form params" do
     env = {
       "CONTENT_TYPE" => "application/x-www-form-urlencoded",
       "rack.input"   => StringIO.new("x=y"),
     }
     request = Rack::Request.new(env)
     params = Committee::RequestUnpacker.new(request).call
+    assert_equal({}, params)
+  end
+
+  it "unpacks form params with allow_form_params" do
+    env = {
+      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+      "rack.input"   => StringIO.new("x=y"),
+    }
+    request = Rack::Request.new(env)
+    params = Committee::RequestUnpacker.new(request, allow_form_params: true).call
     assert_equal({ "x" => "y" }, params)
   end
 


### PR DESCRIPTION
People looking for more strict operation should be able to tweak this setting.
Keep it on (relaxed constraints) by default.
