### PR TITLE
Add wildcard CORS support

### DIFF
--- a/lib/committee/middleware/stub.rb
+++ b/lib/committee/middleware/stub.rb
@@ -8,7 +8,10 @@ module Committee::Middleware
 
     def handle(request)
       if link = @router.find_request_link(request)
-        headers = { "Content-Type" => "application/json" }
+        headers = {
+          "Content-Type" => "application/json",
+          "Access-Control-Allow-Origin" => "*"
+        }
         data = cache(link.method, link.href) do
           Committee::ResponseGenerator.new.call(link)
         end


### PR DESCRIPTION
While using `committee-stub` I was running into cross-origin resource sharing issues.
My app was served on 9000 while committee was served on 8080. 
This PR adds a wildcard `Access-Control-Allow-Origin` header.