### PR TITLE
Validate successfully if a response was an empty list

### DIFF
--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -18,9 +18,13 @@ module Committee
         if !data.is_a?(Array)
           raise InvalidResponse, "List endpoints must return an array of objects."
         end
+
         # only consider the first object during the validation from here on
         # (but only in cases where `targetSchema` is not set)
         data = data[0]
+
+        # if the array was empty, allow it through
+        return if data == nil
       end
 
       if !@validator.validate(data)


### PR DESCRIPTION
(Bug fix.) Don't try to validate a null value if an empty list was returned.

/cc @stillinbeta
