### PR TITLE
Handle 204 responses in assert_schema_conform

### DIFF
--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -28,7 +28,7 @@ module Committee::Middleware
     end
 
     def validate?(status)
-      status != 204 and @validate_errors || (200...300).include?(status)
+      Committee::ResponseValidator.validate?(status)
     end
   end
 end

--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -9,6 +9,10 @@ module Committee
       @validator = JsonSchema::Validator.new(schema)
     end
 
+    def self.validate?(status)
+      status != 204 and @validate_errors || (200...300).include?(status)
+    end
+
     def call(status, headers, data)
       unless status == 204 # 204 No Content
         response = Rack::Response.new(data, status, headers)

--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -32,7 +32,7 @@ module Committee
         return if data == nil
       end
 
-      if !@validator.validate(data)
+      if self.class.validate?(status) && !@validator.validate(data)
         errors = JsonSchema::SchemaError.aggregate(@validator.errors).join("\n")
         raise InvalidResponse, "Invalid response.\n\n#{errors}"
       end

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -18,8 +18,10 @@ module Committee::Test
         raise Committee::InvalidResponse.new(response)
       end
 
-      data = MultiJson.decode(last_response.body)
-      Committee::ResponseValidator.new(link).call(last_response.status, last_response.headers, data)
+      if validate_response?(last_response.status)
+        data = MultiJson.decode(last_response.body)
+        Committee::ResponseValidator.new(link).call(last_response.status, last_response.headers, data)
+      end
     end
 
     def assert_schema_content_type
@@ -43,6 +45,10 @@ module Committee::Test
 
     def warn_string_deprecated
       Committee.warn_deprecated("Committee: returning a string from `#schema_contents` is deprecated; please return a deserialized hash instead.")
+    end
+
+    def validate_response?(status)
+      Committee::ResponseValidator.validate?(status)
     end
   end
 end

--- a/test/response_validator_test.rb
+++ b/test/response_validator_test.rb
@@ -32,6 +32,11 @@ describe Committee::ResponseValidator do
     call
   end
 
+  it "passes through a 204 No Content response" do
+    @status, @headers, @data = 204, {}, nil
+    call
+  end
+
   it "detects an improperly formatted list response" do
     @link = @list_link
     @link.target_schema = nil


### PR DESCRIPTION
Expands on @ronen's fix in #59, by allowing 204 responses through `assert_schema_conform`

This moves the responsbility of checking if a response should be validated from `Committee::Middleware::ResponseValidation#validate?` to `Committee::ResponseValidator.validate?` and performs the same check in `assert_schema_conform`.