### PR TITLE
Fix "Content-Type" validation

### DIFF
--- a/lib/committee/request_validator.rb
+++ b/lib/committee/request_validator.rb
@@ -19,7 +19,7 @@ module Committee
 
     def check_content_type!(request, data)
       if request.content_type && !empty_request?(request)
-        unless Rack::Mime.match?(@link.enc_type, request.content_type)
+        unless Rack::Mime.match?(request.content_type, @link.enc_type)
           raise Committee::InvalidRequest,
             %{"Content-Type" request header must be set to "#{@link.enc_type}".}
         end


### PR DESCRIPTION
Hello, I found the issue about "Content-Type" validation and fix it.

Here is sample. I wrote JSON Schema like this,

```json

{
  "title": "Material",
  "definitions": {
    "someDefinitions": "someDefinitions"
  },
  "description": "Material",
  "links" : [
    {
      "description" : "Create Material",
      "href" : "/api/v1/materials",
      "method" : "POST",
      "rel" : "self",
      "encType" : "multipart/*"
    }
  ],
  "properties": {
    "someProperties": "someProperties"
  }
}
```

then, made request like this,

```HTTP
POST /api/v1/materials HTTP/1.1
Host: localhost:3000
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW

----WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="texture"; filename="sample_texture.jpg"
Content-Type: image/jpeg


----WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="title"

sample_title
----WebKitFormBoundary7MA4YWxkTrZu0gW
```

then, I received error message like this

```JSON
{
  "error": {
    "status": 400,
    "message": "\"Content-Type\" request header must be set to \"multipart/*\"."
  }
}
```

This problem was caused by arguments order, they are used by ```Committee::RequestValidator``` for call ```Rack::Mime.match?``` .
