### PR TITLE
Check request.media_type instead of content_type.

### DIFF
--- a/lib/committee/request_validator.rb
+++ b/lib/committee/request_validator.rb
@@ -18,8 +18,8 @@ module Committee
     private
 
     def check_content_type!(request, data)
-      if request.content_type && !empty_request?(request)
-        unless Rack::Mime.match?(request.content_type, @link.enc_type)
+      if request.media_type && !empty_request?(request)
+        unless Rack::Mime.match?(request.media_type, @link.enc_type)
           raise Committee::InvalidRequest,
             %{"Content-Type" request header must be set to "#{@link.enc_type}".}
         end

--- a/test/request_validator_test.rb
+++ b/test/request_validator_test.rb
@@ -23,6 +23,18 @@ describe Committee::RequestValidator do
     call(data)
   end
 
+  it "passes through a valid request with Content-Type options" do
+    @request =
+      Rack::Request.new({
+      "CONTENT_TYPE" => "application/json; charset=utf-8",
+      "rack.input"   => StringIO.new("{}"),
+    })
+    data = {
+      "name" => "heroku-api",
+    }
+    call(data)
+  end
+
   it "detects an invalid request Content-Type" do
     e = assert_raises(Committee::InvalidRequest) {
       @request =


### PR DESCRIPTION
This will allow `Content-Type` header values such as `application/json;charset=utf-8`. Similar to https://github.com/interagent/pliny/pull/122.