### PR TITLE
Unpack complex JSON types in the request body

### DIFF
--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -11,7 +11,7 @@ module Committee
     def call
       # if Content-Type is empty or JSON, and there was a request body, try to
       # interpret it as JSON
-      params = if !@request.content_type || @request.content_type =~ %r{application/json}
+      params = if !@request.content_type || @request.content_type =~ %r{application/.*json}
         parse_json
       elsif @optimistic_json
         parse_json rescue MultiJson::LoadError nil


### PR DESCRIPTION
This allows more complex JSON types to be unpacked for validation. For example, the JSON API media type `application/vnd.api+json`