### PR TITLE
Response Validator: match response content_type to link enc_type

### DIFF
--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -11,7 +11,8 @@ module Committee
 
     def call(status, headers, data)
       unless status == 204 # 204 No Content
-        check_content_type!(headers)
+        response = Rack::Response.new(data, status, headers)
+        check_content_type!(response)
       end
 
       if @link.rel == "instances" && !@link.target_schema
@@ -35,13 +36,10 @@ module Committee
 
     private
 
-    def check_content_type!(headers)
-      match = [%r{application/json}, %r{application/schema\+json}].any? { |m|
-        headers["Content-Type"] =~ m
-      }
-      unless match
+    def check_content_type!(response)
+      unless Rack::Mime.match?(response.content_type.to_s, @link.enc_type)
         raise Committee::InvalidResponse,
-          %{"Content-Type" response header must be set to "application/json".}
+          %{"Content-Type" response header must be set to "#{@link.enc_type}".}
       end
     end
   end

--- a/test/response_validator_test.rb
+++ b/test/response_validator_test.rb
@@ -35,21 +35,24 @@ describe Committee::ResponseValidator do
     assert_equal message, e.message
   end
 
-  it "detects an invalid response Content-Type" do
+  it "detects a blank response Content-Type" do
     @headers = {}
     e = assert_raises(Committee::InvalidResponse) { call }
     message =
-      %{"Content-Type" response header must be set to "application/json".}
+      %{"Content-Type" response header must be set to "#{@link.enc_type}".}
+    assert_equal message, e.message
+  end
+
+  it "detects an invalid response Content-Type" do
+    @headers = { "Content-Type" => "text/html" }
+    e = assert_raises(Committee::InvalidResponse) { call }
+    message =
+      %{"Content-Type" response header must be set to "#{@link.enc_type}".}
     assert_equal message, e.message
   end
 
   it "allows no Content-Type for 204 No Content" do
     @status, @headers = 204, {}
-    call
-  end
-
-  it "allows application/schema+json in responses as well" do
-    @headers = { "Content-Type" => "application/schema+json" }
     call
   end
 


### PR DESCRIPTION
Previously the Response Validator was hardcoded to only check the response's `Content-Type` against two regexps. This meant that if you weren't using one of those, you couldn't use the response validator.

The updates are meant to match up with how things are done in the Request Validator (hence the use of `Rack::Response`) and match against a link's `encType`.