### PR TITLE
Strip Content-Type options for response

### DIFF
--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -36,8 +36,12 @@ module Committee
 
     private
 
+    def response_media_type(response)
+      response.content_type.to_s.split(";").first.to_s
+    end
+
     def check_content_type!(response)
-      unless Rack::Mime.match?(response.content_type.to_s, @link.enc_type)
+      unless Rack::Mime.match?(response_media_type(response), @link.enc_type)
         raise Committee::InvalidResponse,
           %{"Content-Type" response header must be set to "#{@link.enc_type}".}
       end

--- a/test/response_validator_test.rb
+++ b/test/response_validator_test.rb
@@ -21,6 +21,11 @@ describe Committee::ResponseValidator do
     call
   end
 
+  it "passes through a valid response with Content-Type options" do
+    @headers = { "Content-Type" => "application/json; charset=utf-8" }
+    call
+  end
+
   it "passes through a valid list response" do
     @data = [@data]
     @link = @list_link


### PR DESCRIPTION
Hi, After committee upgrade from 1.6.2 to 1.6.5 my tests starts to fail because of Content-Type for response is set to "application/json; charset=utf-8". Of course I can cure this easily by setting encType in my schema, but what do you think about such more general fix for that?

BR,
Arturs