### PR TITLE
Pluggable Error JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Options:
 
 * `allow_form_params`: Specifies that input can alternatively be specified as `application/x-www-form-urlencoded` parameters when possible. This won't work for more complex schema validations.
 * `allow_query_params`: Specifies that query string parameters will be taken into consideration when doing validation (defaults to `true`).
+* `error_class`: Specifies the class to use for formatting and outputting validation errors (defaults to `Committee::ValidationError`)
 * `optimistic_json`: Will attempt to parse JSON in the request body even without a `Content-Type: application/json` before falling back to other options (defaults to `false`).
 * `prefix`: Mounts the middleware to respond at a configured prefix.
 * `raise`: Raise an exception on error instead of responding with a generic error body (defaults to `false`).
@@ -24,27 +25,27 @@ Some examples of use:
 ``` bash
 # missing required parameter
 $ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api"}'
-{"id":"invalid_params","error":"Require params: recipient."}
+{"id":"invalid_params","message":"Require params: recipient."}
 
 # missing required parameter (should have &query=...)
 $ curl -X GET http://localhost:9292/search?category=all
-{"id":"invalid_params","error":"Require params: query."}
+{"id":"invalid_params","message":"Require params: query."}
 
 # contains an unknown parameter
 $ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api","recipient":"api@heroku.com","sender":"api@heroku.com"}'
-{"id":"invalid_params","error":"Unknown params: sender."}
+{"id":"invalid_params","message":"Unknown params: sender."}
 
 # invalid type
 $ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api","recipient":7}'
-{"id":"invalid_params","error":"Invalid type for key \"recipient\": expected 7 to be [\"string\"]."}%
+{"id":"invalid_params","message":"Invalid type for key \"recipient\": expected 7 to be [\"string\"]."}
 
 # invalid format (supports date-time, email, uuid)
 $ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api","recipient":"api@heroku"}'
-{"id":"invalid_params","error":"Invalid format for key \"recipient\": expected \"api@heroku\" to be \"email\"."
+{"id":"invalid_params","message":"Invalid format for key \"recipient\": expected \"api@heroku\" to be \"email\"."
 
 # invalid pattern
 $ curl -X POST http://localhost:9292/apps -H "Content-Type: application/json" -d '{"name":"$#%"}'
-{"id":"invalid_params","error":"Invalid pattern for key \"name\": expected $#% to match \"(?-mix:^[a-z][a-z0-9-]{3,30}$)\"."}
+{"id":"invalid_params","message":"Invalid pattern for key \"name\": expected $#% to match \"(?-mix:^[a-z][a-z0-9-]{3,30}$)\"."}
 ```
 
 ## Committee::Middleware::Stub
@@ -111,6 +112,7 @@ This piece of middleware validates the contents of the response received from up
 
 Options:
 
+* `error_class`: Specifies the class to use for formatting and outputting validation errors (defaults to `Committee::ValidationError`)
 * `prefix`: Mounts the middleware to respond at a configured prefix.
 * `raise`: Raise an exception on error instead of responding with a generic error body (defaults to `false`).
 * `validate_errors`: Also validate non-2xx responses (defaults to `false`).
@@ -134,7 +136,50 @@ The middleware will raise an error to indicate what the problems are:
 ``` bash
 # missing keys in response
 $ curl -X GET http://localhost:9292/apps
-{"id":"invalid_response","error":"Missing keys in response: archived_at, buildpack_provided_description, created_at, git_url, id, maintenance, name, owner:email, owner:id, region:id, region:name, released_at, repo_size, slug_size, stack:id, stack:name, updated_at, web_url."}
+{"id":"invalid_response","message":"Missing keys in response: archived_at, buildpack_provided_description, created_at, git_url, id, maintenance, name, owner:email, owner:id, region:id, region:name, released_at, repo_size, slug_size, stack:id, stack:name, updated_at, web_url."}
+```
+
+## Validation Errors
+
+Committee will by default respond with a generic error JSON body for validation errors (when the `raise` middleware option is `false`).
+
+Here's an example error to show the default format:
+
+```json
+{
+  "id":"invalid_response",
+  "message":"Missing keys in response: archived_at, buildpack_provided_description, created_at, git_url, id, maintenance, name, owner:email, owner:id, region:id, region:name, released_at, repo_size, slug_size, stack:id, stack:name, updated_at, web_url."
+}
+```
+
+You can customize this JSON body by setting the `error_class` middleware option. The `error_class` will be instantiated with: `status`, `id`, and `message`.
+
+* `status`: HTTP status code
+* `id`: HTTP status name/string
+* `message`: error message
+
+Here's an example of a class to format errors according to [JSON API](http://jsonapi.org/format/#errors):
+
+```ruby
+module MyAPI
+  class ValidationError < Committee::ValidationError
+    def error_body
+      {
+        errors: [
+          { status: id, detail: message }
+        ]
+      }
+    end
+
+    def render
+      [
+        status,
+        { "Content-Type" => "application/vnd.api+json" },
+        [MultiJson.encode(error_body)]
+      ]
+    end
+  end
+end
 ```
 
 ## Test Assertions

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -8,6 +8,7 @@ require_relative "committee/request_validator"
 require_relative "committee/response_generator"
 require_relative "committee/response_validator"
 require_relative "committee/router"
+require_relative "committee/validation_error"
 
 require_relative "committee/middleware/base"
 require_relative "committee/middleware/request_validation"

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -3,12 +3,14 @@ module Committee::Middleware
     def initialize(app, options={})
       @app = app
 
+      @error_class = options.fetch(:error_class, Committee::ValidationError)
       @params_key = options[:params_key] || "committee.params"
       data = options[:schema] || raise("need option `schema`")
       if data.is_a?(String)
         warn_string_deprecated
         data = MultiJson.decode(data)
       end
+      @raise = options[:raise]
       @schema = JsonSchema.parse!(data)
       @schema.expand_references!
       @router = Committee::Router.new(@schema, options)
@@ -25,11 +27,6 @@ module Committee::Middleware
     end
 
     private
-
-    def render_error(status, id, message)
-      [status, { "Content-Type" => "application/json" },
-        [MultiJson.encode({ id: id, message: message }, pretty: true)]]
-    end
 
     def warn_string_deprecated
       Committee.warn_deprecated("Committee: passing a string to `schema` option is deprecated; please send a deserialized hash instead.")

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -5,7 +5,6 @@ module Committee::Middleware
       @allow_form_params  = options.fetch(:allow_form_params, true)
       @allow_query_params = options.fetch(:allow_query_params, true)
       @optimistic_json    = options.fetch(:optimistic_json, false)
-      @raise              = options[:raise]
       @strict             = options[:strict]
 
       # deprecated
@@ -31,14 +30,17 @@ module Committee::Middleware
       end
     rescue Committee::BadRequest, Committee::InvalidRequest
       raise if @raise
-      render_error(400, :bad_request, $!.message)
+      @error_class.new(400, :bad_request, $!.message).render
     rescue Committee::NotFound
       raise if @raise
-      render_error(404, :not_found,
-        "That request method and path combination isn't defined.")
+      @error_class.new(
+        404,
+        :not_found,
+        "That request method and path combination isn't defined."
+      ).render
     rescue MultiJson::LoadError
       raise Committee::InvalidRequest if @raise
-      render_error(400, :bad_request, "Request body wasn't valid JSON.")
+      @error_class.new(400, :bad_request, "Request body wasn't valid JSON.").render
     end
   end
 end

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -2,7 +2,6 @@ module Committee::Middleware
   class ResponseValidation < Base
     def initialize(app, options={})
       super
-      @raise = options[:raise]
       @validate_errors = options[:validate_errors]
     end
 
@@ -21,10 +20,10 @@ module Committee::Middleware
       [status, headers, response]
     rescue Committee::InvalidResponse
       raise if @raise
-      render_error(500, :invalid_response, $!.message)
+      @error_class.new(500, :invalid_response, $!.message).render
     rescue MultiJson::LoadError
       raise Committee::InvalidResponse if @raise
-      render_error(500, :invalid_response, "Response wasn't valid JSON.")
+      @error_class.new(500, :invalid_response, "Response wasn't valid JSON.").render
     end
 
     def validate?(status)

--- a/lib/committee/validation_error.rb
+++ b/lib/committee/validation_error.rb
@@ -1,0 +1,23 @@
+module Committee
+  class ValidationError
+    attr_reader :id, :message, :status
+
+    def initialize(status, id, message)
+      @status = status
+      @id = id
+      @message = message
+    end
+
+    def error_body
+      { id: id, message: message }
+    end
+
+    def render
+      [
+        status,
+        { "Content-Type" => "application/json" },
+        [MultiJson.encode(error_body)]
+      ]
+    end
+  end
+end

--- a/test/validation_error_test.rb
+++ b/test/validation_error_test.rb
@@ -1,0 +1,23 @@
+require_relative "test_helper"
+
+describe Committee::ValidationError do
+  before do
+    @error = Committee::ValidationError.new(400, :bad_request, "Error")
+  end
+
+  it "creates an error body with the id and message" do
+    assert_equal @error.error_body, { id: :bad_request, message: "Error" }
+  end
+
+  it "creates a Rack response object to render" do
+    body = { id: :bad_request, message: "Error" }
+
+    response = [
+      400,
+      { "Content-Type" => "application/json" },
+      [MultiJson.encode(body)]
+    ]
+
+    assert_equal @error.render, response
+  end
+end


### PR DESCRIPTION
Pretty basic implementation of pluggable errors. See https://github.com/interagent/committee/issues/68.

`error_class` is the option to specify your own error class.

I can add a note to the `README` documenting this feature assuming the rest is fine.