### PR TITLE
Strip Content-Type options for request

### DIFF
--- a/lib/committee/request_validator.rb
+++ b/lib/committee/request_validator.rb
@@ -17,9 +17,13 @@ module Committee
 
     private
 
+    def request_media_type(request)
+      request.content_type.to_s.split(";").first.to_s
+    end
+
     def check_content_type!(request, data)
-      if request.media_type && !empty_request?(request)
-        unless Rack::Mime.match?(request.media_type, @link.enc_type)
+      if request_media_type(request) && !empty_request?(request)
+        unless Rack::Mime.match?(request.media_type.to_s, @link.enc_type)
           raise Committee::InvalidRequest,
             %{"Content-Type" request header must be set to "#{@link.enc_type}".}
         end

--- a/lib/committee/request_validator.rb
+++ b/lib/committee/request_validator.rb
@@ -22,8 +22,9 @@ module Committee
     end
 
     def check_content_type!(request, data)
-      if request_media_type(request) && !empty_request?(request)
-        unless Rack::Mime.match?(request_media_type(request), @link.enc_type)
+      content_type = request_media_type(request)
+      if content_type && !empty_request?(request)
+        unless Rack::Mime.match?(content_type, @link.enc_type)
           raise Committee::InvalidRequest,
             %{"Content-Type" request header must be set to "#{@link.enc_type}".}
         end

--- a/lib/committee/request_validator.rb
+++ b/lib/committee/request_validator.rb
@@ -32,7 +32,7 @@ module Committee
 
     def empty_request?(request)
       # small optimization: assume GET and DELETE don't have bodies
-      return true if request.get? || request.delete?
+      return true if request.get? || request.delete? || !request.body
 
       data = request.body.read
       request.body.rewind

--- a/lib/committee/request_validator.rb
+++ b/lib/committee/request_validator.rb
@@ -23,7 +23,7 @@ module Committee
 
     def check_content_type!(request, data)
       if request_media_type(request) && !empty_request?(request)
-        unless Rack::Mime.match?(request.media_type.to_s, @link.enc_type)
+        unless Rack::Mime.match?(request_media_type(request), @link.enc_type)
           raise Committee::InvalidRequest,
             %{"Content-Type" request header must be set to "#{@link.enc_type}".}
         end

--- a/test/request_validator_test.rb
+++ b/test/request_validator_test.rb
@@ -16,6 +16,11 @@ describe Committee::RequestValidator do
     })
   end
 
+  it "passes through a valid request with Content-Type options" do
+    @headers = { "Content-Type" => "application/json; charset=utf-8" }
+    call({})
+  end
+
   it "passes through a valid request" do
     data = {
       "name" => "heroku-api",


### PR DESCRIPTION
(refs. https://github.com/interagent/committee/pull/70)

Hi,  some http clients always set Content-Type options for request, such as "application/json; charset=UTF-8".
This PR strip Content-Type options like PR#70 above.

BR,
dlwr