### PR TITLE
not enc_type but media_type to check response content-type

### DIFF
--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -45,9 +45,9 @@ module Committee
     end
 
     def check_content_type!(response)
-      unless Rack::Mime.match?(response_media_type(response), @link.enc_type)
+      unless Rack::Mime.match?(response_media_type(response), @link.media_type)
         raise Committee::InvalidResponse,
-          %{"Content-Type" response header must be set to "#{@link.enc_type}".}
+          %{"Content-Type" response header must be set to "#{@link.media_type}".}
       end
     end
   end


### PR DESCRIPTION
Obviously, encType is for a request and mediaType is for a response.

Unfortunately there are no existing tests and test shema of specifying mediaType, and I didn't add tests about it.