### PR TITLE
handling optimistic_json on non-JSON body when ContentType is not `application/json`

### DIFF
--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -14,7 +14,11 @@ module Committee
       params = if !@request.media_type || @request.media_type =~ %r{application/.*json}
         parse_json
       elsif @optimistic_json
-        parse_json rescue MultiJson::LoadError nil
+        begin
+          parse_json
+        rescue MultiJson::LoadError
+          nil
+        end
       end
 
       params = if params

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -42,6 +42,16 @@ describe Committee::RequestUnpacker do
     assert_equal({ "x" => "y" }, params)
   end
 
+  it "returns {} when try to unpacks nonJSON under other Content-Types with optimistic_json" do
+    env = {
+      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+      "rack.input"   => StringIO.new('x=y&foo=42'),
+    }
+    request = Rack::Request.new(env)
+    params = Committee::RequestUnpacker.new(request, optimistic_json: true).call
+    assert_equal({}, params)
+  end
+
   it "unpacks an empty hash on an empty request body" do
     env = {
       "CONTENT_TYPE" => "application/json",


### PR DESCRIPTION
I tried to use the optimistic_json option on non-JSON request.body and got an error because the `rescue` keyword was used in wrong way. Regardless that it is a kind of code smell: http://devblog.avdi.org/2012/11/19/rubytapas-022-inline-rescue/ inline rescue cannot have specified exception which it should catch. It always catch all `StandardError` based exceptions, as this example shows:

```ruby
2.2.1 :001 > foo
NameError: undefined local variable or method `foo' for main:Object
	from (irb):1
	from /Users/ravbaker/.rvm/rubies/ruby-2.2.1/bin/irb:11:in `<main>'
2.2.1 :002 > foo rescue NameError nil
NoMethodError: undefined method `NameError' for main:Object
	from (irb):2:in `rescue in irb_binding'
	from (irb):2
	from /Users/ravbaker/.rvm/rubies/ruby-2.2.1/bin/irb:11:in `<main>'
2.2.1 :003 > foo rescue nil
 => nil
```

Hope that this change will solve this issue.