### PR TITLE
Upgrade 2.2.2 -> 2.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 1.9.3-p551
   - 2.1.6
-  - 2.2.2
+  - 2.2.3
 
 cache: bundler
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Committee is tested on the following MRI versions:
 
 - 1.9.3-p551
 - 2.1.6
-- 2.2.2
+- 2.2.3
 
 ## Committee::Middleware::RequestValidation
 


### PR DESCRIPTION
Starts testing under 2.2.3 instead of 2.2.2.