### PR TITLE
More general response generation + tests

### DIFF
--- a/test/response_generator_test.rb
+++ b/test/response_generator_test.rb
@@ -27,6 +27,34 @@ describe Committee::ResponseGenerator do
     assert data.is_a?(Array)
   end
 
+  it "wraps list data in an array" do
+    @link = @list_link
+
+    @link.rel = nil
+
+    data = call
+    assert data.is_a?(Array)
+  end
+
+  it "errors with no known route for generation" do
+    @link = @get_link
+
+    # tweak the schema so that it can't be generated
+    property = @schema.properties["app"].properties["maintenance"]
+    property.data["example"] = nil
+    property.type = []
+
+    e = assert_raises(RuntimeError) do
+      call
+    end
+
+    expected = <<-eos.gsub(/\n +/, "").strip
+      At "#/definitions/app/properties/maintenance": no "example" attribute and 
+      "null" is not allowed; don't know how to generate property.
+    eos
+    assert_equal expected, e.message
+  end
+
   def call
     Committee::ResponseGenerator.new.call(@link)
   end


### PR DESCRIPTION
This patch aims to make response generation a little more general so
that list responses can be generated from subschemas containing nothing
by an `items` attribute rather than having to interpret the special
`instances` keyword under `rel`.

We also add a few tests to verify this new behavior.