### PR TITLE
Allow YAML to be loaded along with JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ module MyAPI
       [
         status,
         { "Content-Type" => "application/vnd.api+json" },
-        [MultiJson.encode(error_body)]
+        [JSON.generate(error_body)]
       ]
     end
   end
@@ -206,7 +206,7 @@ describe Committee::Middleware::Stub do
     Sinatra.new do
       get "/" do
         content_type :json
-        MultiJson.encode({ "foo" => "bar" })
+        JSON.generate({ "foo" => "bar" })
       end
     end
   end

--- a/bin/committee-stub
+++ b/bin/committee-stub
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "multi_json"
 require 'optparse'
+require 'yaml'
 
 require_relative "../lib/committee"
 
@@ -33,7 +33,7 @@ unless args.count == 1
   exit
 end
 
-schema = MultiJson.decode(File.read(args[0]))
+schema = ::YAML.load(File.read(args[0]))
 
 app = Rack::Builder.new {
   unless options[:tolerant]

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.files         = Dir["{bin,lib,test}/**/*.rb"]
 
   s.add_dependency "json_schema", "~> 0.6", ">= 0.6.1"
-  s.add_dependency "multi_json", "~> 1.10"
   s.add_dependency "rack", "~> 1.5"
 
   s.add_development_dependency "minitest", "~> 5.3"

--- a/examples/app.rb
+++ b/examples/app.rb
@@ -4,7 +4,7 @@ require "securerandom"
 require "sinatra/base"
 
 class App < Sinatra::Base
-  SCHEMA = MultiJson.decode(File.read("schema.json"))
+  SCHEMA = JSON.parse(File.read("schema.json"))
 
   # The request validator verifies that the required input parameters (and no
   # unknown input parameters) are included with the request and that they are

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -1,3 +1,4 @@
+require "json"
 require "json_schema"
 require "rack"
 

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -1,5 +1,4 @@
 require "json_schema"
-require "multi_json"
 require "rack"
 
 require_relative "committee/errors"

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -8,7 +8,7 @@ module Committee::Middleware
       data = options[:schema] || raise("need option `schema`")
       if data.is_a?(String)
         warn_string_deprecated
-        data = MultiJson.decode(data)
+        data = JSON.parse(data)
       end
       @raise = options[:raise]
       @schema = JsonSchema.parse!(data)

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -39,7 +39,7 @@ module Committee::Middleware
         :not_found,
         "That request method and path combination isn't defined."
       ).render
-    rescue MultiJson::LoadError
+    rescue JSON::ParserError
       raise Committee::InvalidRequest if @raise
       @error_class.new(400, :bad_request, "Request body wasn't valid JSON.").render
     end

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -13,7 +13,7 @@ module Committee::Middleware
         response.each do |chunk|
           full_body << chunk
         end
-        data = MultiJson.decode(full_body)
+        data = JSON.parse(full_body)
         Committee::ResponseValidator.new(link).call(status, headers, data)
       end
 
@@ -21,7 +21,7 @@ module Committee::Middleware
     rescue Committee::InvalidResponse
       raise if @raise
       @error_class.new(500, :invalid_response, $!.message).render
-    rescue MultiJson::LoadError
+    rescue JSON::ParserError
       raise Committee::InvalidResponse if @raise
       @error_class.new(500, :invalid_response, "Response wasn't valid JSON.").render
     end

--- a/lib/committee/middleware/stub.rb
+++ b/lib/committee/middleware/stub.rb
@@ -26,7 +26,7 @@ module Committee::Middleware
           headers.merge!(call_headers)
         end
         status = link.rel == "create" ? 201 : 200
-        [status, headers, [MultiJson.encode(data, pretty: true)]]
+        [status, headers, [JSON.generate(data, pretty: true)]]
       else
         @app.call(request.env)
       end

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -16,7 +16,7 @@ module Committee
       elsif @optimistic_json
         begin
           parse_json
-        rescue MultiJson::LoadError
+        rescue JSON::ParserError
           nil
         end
       end
@@ -66,7 +66,7 @@ module Committee
     def parse_json
       if (body = @request.body.read).length != 0
         @request.body.rewind
-        hash = MultiJson.decode(body)
+        hash = JSON.parse(body)
         # We want a hash specifically. '42', 42, and [42] will all be
         # decoded properly, but we can't use them here.
         if !hash.is_a?(Hash)

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -3,7 +3,7 @@ module Committee::Test
     def assert_schema_conform
       if (data = schema_contents).is_a?(String)
         warn_string_deprecated
-        data = MultiJson.decode(data)
+        data = JSON.parse(data)
       end
 
       @schema ||= begin
@@ -19,7 +19,7 @@ module Committee::Test
       end
 
       if validate_response?(last_response.status)
-        data = MultiJson.decode(last_response.body)
+        data = JSON.parse(last_response.body)
         Committee::ResponseValidator.new(link).call(last_response.status, last_response.headers, data)
       end
     end
@@ -32,7 +32,7 @@ module Committee::Test
     # easier to access as a string
     # blob
     def schema_contents
-      MultiJson.decode(File.read(schema_path))
+      JSON.parse(File.read(schema_path))
     end
 
     def schema_path

--- a/lib/committee/validation_error.rb
+++ b/lib/committee/validation_error.rb
@@ -16,7 +16,7 @@ module Committee
       [
         status,
         { "Content-Type" => "application/json" },
-        [MultiJson.encode(error_body)]
+        [JSON.generate(error_body)]
       ]
     end
   end

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -13,7 +13,7 @@ describe Committee::Middleware::RequestValidation do
       "name" => "cloudnasium"
     }
     header "Content-Type", "application/json"
-    post "/apps", MultiJson.encode(params)
+    post "/apps", JSON.generate(params)
     assert_equal 200, last_response.status
   end
 
@@ -23,7 +23,7 @@ describe Committee::Middleware::RequestValidation do
     params = {
       "name" => 1
     }
-    post "/apps", MultiJson.encode(params)
+    post "/apps", JSON.generate(params)
     assert_equal 400, last_response.status
     assert_match /invalid request/i, last_response.body
   end
@@ -42,7 +42,7 @@ describe Committee::Middleware::RequestValidation do
       "name" => "cloudnasium"
     }
     header "Content-Type", "application/json"
-    post "/v1/apps", MultiJson.encode(params)
+    post "/v1/apps", JSON.generate(params)
     assert_equal 200, last_response.status
   end
 
@@ -60,7 +60,7 @@ describe Committee::Middleware::RequestValidation do
       "name" => "cloudnasium"
     }
     header "Content-Type", "application/json"
-    post "/apps", MultiJson.encode(params)
+    post "/apps", JSON.generate(params)
     assert_equal 200, last_response.status
   end
 
@@ -90,7 +90,7 @@ describe Committee::Middleware::RequestValidation do
       "name" => "cloudnasium"
     }
     header "Content-Type", "text/html"
-    post "/apps", MultiJson.encode(params)
+    post "/apps", JSON.generate(params)
     assert_equal 200, last_response.status
   end
 
@@ -98,7 +98,7 @@ describe Committee::Middleware::RequestValidation do
 
   def new_rack_app(options = {})
     options = {
-      schema: MultiJson.decode(File.read("./test/data/schema.json"))
+      schema: JSON.parse(File.read("./test/data/schema.json"))
     }.merge(options)
     Rack::Builder.new {
       use Committee::Middleware::RequestValidation, options

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -8,7 +8,7 @@ describe Committee::Middleware::ResponseValidation do
   end
 
   it "passes through a valid response" do
-    @app = new_rack_app(MultiJson.encode([ValidApp]))
+    @app = new_rack_app(JSON.generate([ValidApp]))
     get "/apps"
     assert_equal 200, last_response.status
   end
@@ -40,14 +40,14 @@ describe Committee::Middleware::ResponseValidation do
   end
 
   it "takes a prefix" do
-    @app = new_rack_app(MultiJson.encode([ValidApp]), {}, prefix: "/v1")
+    @app = new_rack_app(JSON.generate([ValidApp]), {}, prefix: "/v1")
     get "/v1/apps"
     assert_equal 200, last_response.status
   end
 
   it "warns when sending a deprecated string" do
     mock(Committee).warn_deprecated.with_any_args
-    @app = new_rack_app(MultiJson.encode([ValidApp]), {},
+    @app = new_rack_app(JSON.generate([ValidApp]), {},
       schema: File.read("./test/data/schema.json"))
     get "/apps"
     assert_equal 200, last_response.status
@@ -67,7 +67,7 @@ describe Committee::Middleware::ResponseValidation do
       "Content-Type" => "application/json"
     }.merge(headers)
     options = {
-      schema: MultiJson.decode(File.read("./test/data/schema.json"))
+      schema: JSON.parse(File.read("./test/data/schema.json"))
     }.merge(options)
     Rack::Builder.new {
       use Committee::Middleware::ResponseValidation, options

--- a/test/middleware/stub_test.rb
+++ b/test/middleware/stub_test.rb
@@ -11,7 +11,7 @@ describe Committee::Middleware::Stub do
     @app = new_rack_app
     get "/apps/heroku-api"
     assert_equal 200, last_response.status
-    data = MultiJson.decode(last_response.body)
+    data = JSON.parse(last_response.body)
     assert_equal ValidApp.keys.sort, data.keys.sort
   end
 
@@ -26,7 +26,7 @@ describe Committee::Middleware::Stub do
     get "/apps/heroku-api"
     assert_equal 200, last_response.status
     assert_equal ValidApp,
-      MultiJson.decode(last_response.headers["Committee-Response"])
+      JSON.parse(last_response.headers["Committee-Response"])
   end
 
   it "optionally returns the application's response" do
@@ -34,7 +34,7 @@ describe Committee::Middleware::Stub do
     get "/apps/heroku-api"
     assert_equal 429, last_response.status
     assert_equal ValidApp,
-      MultiJson.decode(last_response.headers["Committee-Response"])
+      JSON.parse(last_response.headers["Committee-Response"])
       assert_equal "", last_response.body
   end
 
@@ -42,7 +42,7 @@ describe Committee::Middleware::Stub do
     @app = new_rack_app(prefix: "/v1")
     get "/v1/apps/heroku-api"
     assert_equal 200, last_response.status
-    data = MultiJson.decode(last_response.body)
+    data = JSON.parse(last_response.body)
     assert_equal ValidApp.keys.sort, data.keys.sort
   end
 
@@ -51,7 +51,7 @@ describe Committee::Middleware::Stub do
     @app = new_rack_app(schema: File.read("./test/data/schema.json"))
     get "/apps/heroku-api"
     assert_equal 200, last_response.status
-    data = MultiJson.decode(last_response.body)
+    data = JSON.parse(last_response.body)
     assert_equal ValidApp.keys.sort, data.keys.sort
   end
 
@@ -60,12 +60,12 @@ describe Committee::Middleware::Stub do
   def new_rack_app(options = {})
     suppress = options.delete(:suppress)
     options = {
-      schema: MultiJson.decode(File.read("./test/data/schema.json"))
+      schema: JSON.parse(File.read("./test/data/schema.json"))
     }.merge(options)
     Rack::Builder.new {
       use Committee::Middleware::Stub, options
       run lambda { |env|
-        headers = { "Committee-Response" => MultiJson.encode(env["committee.response"]) }
+        headers = { "Committee-Response" => JSON.generate(env["committee.response"]) }
         env["committee.suppress"] = suppress
         [429, headers, []]
       }

--- a/test/request_validator_test.rb
+++ b/test/request_validator_test.rb
@@ -5,7 +5,7 @@ require "stringio"
 describe Committee::RequestValidator do
   before do
     @schema =
-      JsonSchema.parse!(MultiJson.decode(File.read("./test/data/schema.json")))
+      JsonSchema.parse!(JSON.parse(File.read("./test/data/schema.json")))
     @schema.expand_references!
     # POST /apps/:id
     @link = @link = @schema.properties["app"].links[0]

--- a/test/response_generator_test.rb
+++ b/test/response_generator_test.rb
@@ -3,7 +3,7 @@ require_relative "test_helper"
 describe Committee::ResponseGenerator do
   before do
     @schema =
-      JsonSchema.parse!(MultiJson.decode(File.read("./test/data/schema.json")))
+      JsonSchema.parse!(JSON.parse(File.read("./test/data/schema.json")))
     @schema.expand_references!
     # GET /apps/:id
     @get_link = @link = @schema.properties["app"].links[2]

--- a/test/response_validator_test.rb
+++ b/test/response_validator_test.rb
@@ -8,7 +8,7 @@ describe Committee::ResponseValidator do
     }
     @data = ValidApp.dup
     @schema =
-      JsonSchema.parse!(MultiJson.decode(File.read("./test/data/schema.json")))
+      JsonSchema.parse!(JSON.parse(File.read("./test/data/schema.json")))
     @schema.expand_references!
     # GET /apps/:id
     @get_link = @link = @schema.properties["app"].links[2]

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -30,7 +30,7 @@ describe Committee::Router do
   end
 
   def router(options = {})
-    data = MultiJson.decode(File.read("./test/data/schema.json"))
+    data = JSON.parse(File.read("./test/data/schema.json"))
     schema = JsonSchema.parse!(data)
     schema.expand_references!
     Committee::Router.new(schema, options)

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -21,13 +21,13 @@ describe Committee::Middleware::Stub do
 
   describe "#assert_schema_conform" do
     it "passes through a valid response" do
-      @app = new_rack_app(MultiJson.encode([ValidApp]))
+      @app = new_rack_app(JSON.generate([ValidApp]))
       get "/apps"
       assert_schema_conform
     end
 
     it "detects an invalid response Content-Type" do
-      @app = new_rack_app(MultiJson.encode([ValidApp]), {})
+      @app = new_rack_app(JSON.generate([ValidApp]), {})
       get "/apps"
       e = assert_raises(Committee::InvalidResponse) do
         assert_schema_conform
@@ -38,7 +38,7 @@ describe Committee::Middleware::Stub do
     it "warns when sending a deprecated string" do
       stub(self).schema_contents { File.read(schema_path) }
       mock(Committee).warn_deprecated.with_any_args
-      @app = new_rack_app(MultiJson.encode([ValidApp]))
+      @app = new_rack_app(JSON.generate([ValidApp]))
       get "/apps"
       assert_schema_conform
     end

--- a/test/validation_error_test.rb
+++ b/test/validation_error_test.rb
@@ -15,7 +15,7 @@ describe Committee::ValidationError do
     response = [
       400,
       { "Content-Type" => "application/json" },
-      [MultiJson.encode(body)]
+      [JSON.generate(body)]
     ]
 
     assert_equal @error.render, response


### PR DESCRIPTION
Use `YAML.load` which will load either JSON or YAML formatted schemas.
YAML is often more convenient to work with than JSON as it's much more
easily consumed by a human. Prmd already has this particular nicety, so
this changes Committee's executable to match.

We also pull the `multi_json` dependency now that JSON is already pretty
well baked into the Ruby language.