### PR TITLE
Create a mechanism for normalized release with Bundler's tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,11 @@ Run a particular test suite or test:
 bundle exec ruby -Ilib -Itest test/router_test.rb
 bundle exec ruby -Ilib -Itest test/router_test.rb -n /prefix/
 ```
+
+## Release
+
+Use the `release` task:
+
+```
+bundle exec rake release
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
+require 'bundler'
 require 'rake/testtask'
+
+Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new do |t|
   t.libs << "test"


### PR DESCRIPTION
I always forget to push commits and/or tags and/or gems during a release, so let's normalize the process using Bundler's built-in helpers for it.