### PR TITLE
Allow `committee.response` value to be replaced

### DIFF
--- a/lib/committee/middleware/stub.rb
+++ b/lib/committee/middleware/stub.rb
@@ -24,6 +24,10 @@ module Committee::Middleware
           # otherwise keep the headers and whatever data manipulations were
           # made, and stub normally
           headers.merge!(call_headers)
+
+          # allow allow the handler to change the data object (if unchanged, it
+          # will be the same one that we set above)
+          data = request.env["committee.response"]
         end
         status = link.rel == "create" ? 201 : 200
         [status, headers, [JSON.pretty_generate(data)]]


### PR DESCRIPTION
This allows a stub override to replace `committee.response` rather than
forcing it to manipulate the hash in it directly. This can be useful in
cases where an app might want to use immutable hash manipulation
functions instead of mutable ones, for example.