### PR TITLE
Add Ruby 1.9.3 back to Travis test list + official 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 rvm:
+  - 1.9.3
   - 2.0.0-p648
   - 2.1.8
   - 2.2.4
-  - 2.3.0-preview2
+  - 2.3.0
 
 cache: bundler
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Committee is tested on the following MRI versions:
 - 2.0
 - 2.1
 - 2.2
-- 2.3 (preview)
+- 2.3
 
 ## Committee::Middleware::RequestValidation
 


### PR DESCRIPTION
I hate to flip flop on this, but I decided to patch json_schema to still
support 1.9.3 because it only necessitated a change in a single line. As
such, I'm bringing it back to Committee just to keep the version on life
support a bit longer (the real reason is I want to use it in
stripe-ruby's test suite and we're currently supporting versions of Ruby
well past the expiration dates right now, including 1.9.3).

Also move to 2.3.0 from 2.3.0-preview2 now that we have an official
release.