### PR TITLE
Actually respect the validate_errors option to ResponseValidation middleware

### DIFF
--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -5,6 +5,8 @@ module Committee::Middleware
       @validate_errors = options[:validate_errors]
     end
 
+    attr_reader :validate_errors
+
     def handle(request)
       status, headers, response = @app.call(request.env)
 
@@ -14,7 +16,7 @@ module Committee::Middleware
           full_body << chunk
         end
         data = JSON.parse(full_body)
-        Committee::ResponseValidator.new(link).call(status, headers, data)
+        Committee::ResponseValidator.new(link, validate_errors: validate_errors).call(status, headers, data)
       end
 
       [status, headers, response]
@@ -27,7 +29,7 @@ module Committee::Middleware
     end
 
     def validate?(status)
-      Committee::ResponseValidator.validate?(status)
+      Committee::ResponseValidator.validate?(status, validate_errors: validate_errors)
     end
   end
 end

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -1,11 +1,11 @@
 module Committee::Middleware
   class ResponseValidation < Base
+    attr_reader :validate_errors
+
     def initialize(app, options = {})
       super
       @validate_errors = options[:validate_errors]
     end
-
-    attr_reader :validate_errors
 
     def handle(request)
       status, headers, response = @app.call(request.env)

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -16,7 +16,7 @@ module Committee::Middleware
           full_body << chunk
         end
         data = JSON.parse(full_body)
-        Committee::ResponseValidator.new(link, validate_errors: validate_errors).call(status, headers, data)
+        Committee::ResponseValidator.new(link, validate_errors).call(status, headers, data)
       end
 
       [status, headers, response]
@@ -29,7 +29,7 @@ module Committee::Middleware
     end
 
     def validate?(status)
-      Committee::ResponseValidator.validate?(status, validate_errors: validate_errors)
+      Committee::ResponseValidator.validate?(status, validate_errors)
     end
   end
 end

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -1,6 +1,6 @@
 module Committee::Middleware
   class ResponseValidation < Base
-    def initialize(app, options={})
+    def initialize(app, options = {})
       super
       @validate_errors = options[:validate_errors]
     end
@@ -16,7 +16,7 @@ module Committee::Middleware
           full_body << chunk
         end
         data = JSON.parse(full_body)
-        Committee::ResponseValidator.new(link, validate_errors).call(status, headers, data)
+        Committee::ResponseValidator.new(link, validate_errors: validate_errors).call(status, headers, data)
       end
 
       [status, headers, response]
@@ -29,7 +29,7 @@ module Committee::Middleware
     end
 
     def validate?(status)
-      Committee::ResponseValidator.validate?(status, validate_errors)
+      Committee::ResponseValidator.validate?(status, validate_errors: validate_errors)
     end
   end
 end

--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -1,8 +1,8 @@
 module Committee
   class ResponseValidator
-    def initialize(link, validate_errors = false)
+    def initialize(link, options = {})
       @link = link
-      @validate_errors = validate_errors
+      @validate_errors = options[:validate_errors]
 
       # we should eventually move off of validating against parent schema too
       # ... this is a Herokuism and not in the specification
@@ -11,7 +11,9 @@ module Committee
     end
     attr_reader :validate_errors
 
-    def self.validate?(status, validate_errors = false)
+    def self.validate?(status, options = {})
+      validate_errors = options[:validate_errors]
+
       status != 204 and validate_errors || (200...300).include?(status)
     end
 
@@ -34,7 +36,7 @@ module Committee
         return if data == nil
       end
 
-      if self.class.validate?(status, validate_errors) && !@validator.validate(data)
+      if self.class.validate?(status, validate_errors: validate_errors) && !@validator.validate(data)
         errors = JsonSchema::SchemaError.aggregate(@validator.errors).join("\n")
         raise InvalidResponse, "Invalid response.\n\n#{errors}"
       end

--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -1,5 +1,7 @@
 module Committee
   class ResponseValidator
+    attr_reader :validate_errors
+
     def initialize(link, options = {})
       @link = link
       @validate_errors = options[:validate_errors]
@@ -9,7 +11,6 @@ module Committee
       schema = link.target_schema || link.parent
       @validator = JsonSchema::Validator.new(schema)
     end
-    attr_reader :validate_errors
 
     def self.validate?(status, options = {})
       validate_errors = options[:validate_errors]

--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -1,6 +1,6 @@
 module Committee
   class ResponseValidator
-    def initialize(link, validate_errors: false)
+    def initialize(link, validate_errors = false)
       @link = link
       @validate_errors = validate_errors
 
@@ -11,7 +11,7 @@ module Committee
     end
     attr_reader :validate_errors
 
-    def self.validate?(status, validate_errors: false)
+    def self.validate?(status, validate_errors = false)
       status != 204 and validate_errors || (200...300).include?(status)
     end
 
@@ -34,7 +34,7 @@ module Committee
         return if data == nil
       end
 
-      if self.class.validate?(status, validate_errors: validate_errors) && !@validator.validate(data)
+      if self.class.validate?(status, validate_errors) && !@validator.validate(data)
         errors = JsonSchema::SchemaError.aggregate(@validator.errors).join("\n")
         raise InvalidResponse, "Invalid response.\n\n#{errors}"
       end

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -26,6 +26,14 @@ describe Committee::Middleware::ResponseValidation do
     assert_equal 404, last_response.status
   end
 
+  it "optionally validates non-2xx invalid responses" do
+    @app = new_rack_app("", {}, {app_status: 404, validate_errors: true})
+
+    get "/apps"
+    assert_equal 500, last_response.status
+    assert_match /valid JSON/i, last_response.body
+  end
+
   it "passes through a 204 (no content) response" do
     @app = new_rack_app("", {}, app_status: 204)
     get "/apps"


### PR DESCRIPTION
The option existed, and there was an attempt to check it. But the value passed in never made it to the validator where the option was checked. 