### PR TITLE
Option for coercing form parameters

### DIFF
--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -15,6 +15,11 @@ module Committee
 
     # Driver is a base class for driver implementations.
     class Driver
+      # Whether parameters that were form-encoded will be coerced by default.
+      def default_coerce_form_params
+        raise "needs implementation"
+      end
+
       # Whether parameters in a request's path will be considered and coerced
       # by default.
       def default_path_params

--- a/lib/committee/drivers/hyper_schema.rb
+++ b/lib/committee/drivers/hyper_schema.rb
@@ -1,5 +1,10 @@
 module Committee::Drivers
   class HyperSchema < Committee::Drivers::Driver
+    # Whether parameters that were form-encoded will be coerced by default.
+    def default_coerce_form_params
+      false
+    end
+
     # Whether parameters in a request's path will be considered and coerced by
     # default.
     def default_path_params

--- a/lib/committee/drivers/open_api_2.rb
+++ b/lib/committee/drivers/open_api_2.rb
@@ -1,5 +1,10 @@
 module Committee::Drivers
   class OpenAPI2 < Committee::Drivers::Driver
+    # Whether parameters that were form-encoded will be coerced by default.
+    def default_coerce_form_params
+      true
+    end
+
     # Whether parameters in a request's path will be considered and coerced by
     # default.
     def default_path_params

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -9,6 +9,8 @@ module Committee::Middleware
       @optimistic_json     = options.fetch(:optimistic_json, false)
       @strict              = options[:strict]
 
+      @coerce_form_params = options.fetch(:coerce_form_params,
+        @schema.driver.default_coerce_form_params)
       @coerce_path_params = options.fetch(:coerce_path_params,
         @schema.driver.default_path_params)
       @coerce_query_params = options.fetch(:coerce_query_params,
@@ -50,7 +52,9 @@ module Committee::Middleware
         request,
         allow_form_params:  @allow_form_params,
         allow_query_params: @allow_query_params,
-        optimistic_json:    @optimistic_json
+        coerce_form_params: @coerce_form_params,
+        optimistic_json:    @optimistic_json,
+        schema:             link ? link.schema : nil
       ).call
 
       request.env[@params_key].merge!(path_params)

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -5,7 +5,9 @@ module Committee
 
       @allow_form_params  = options[:allow_form_params]
       @allow_query_params = options[:allow_query_params]
+      @coerce_form_params = options[:coerce_form_params]
       @optimistic_json    = options[:optimistic_json]
+      @schema             = options[:schema]
     end
 
     def call
@@ -26,7 +28,16 @@ module Committee
       elsif @allow_form_params && @request.media_type == "application/x-www-form-urlencoded"
         # Actually, POST means anything in the request body, could be from
         # PUT or PATCH too. Silly Rack.
-        indifferent_params(@request.POST)
+        p = @request.POST
+
+        if @coerce_form_params && @schema
+          p.merge!(Committee::StringParamsCoercer.new(
+            p,
+            @schema
+          ).call)
+        end
+
+        p
       else
         {}
       end

--- a/test/drivers/hyper_schema_test.rb
+++ b/test/drivers/hyper_schema_test.rb
@@ -32,6 +32,10 @@ describe Committee::Drivers::HyperSchema do
     end
   end
 
+  it "defaults to not coercing form parameters" do
+    assert_equal false, @driver.default_coerce_form_params
+  end
+
   it "defaults to no path parameters" do
     assert_equal false, @driver.default_path_params
   end

--- a/test/drivers/open_api_2_test.rb
+++ b/test/drivers/open_api_2_test.rb
@@ -111,6 +111,10 @@ describe Committee::Drivers::OpenAPI2 do
     assert_equal "Committee: no definitions section in spec data.", e.message
   end
 
+  it "defaults to coercing form parameters" do
+    assert_equal true, @driver.default_coerce_form_params
+  end
+
   it "defaults to path parameters" do
     assert_equal true, @driver.default_path_params
   end

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -23,11 +23,12 @@ end
 
 describe Committee::Drivers::Driver do
   DRIVER_METHODS = {
-    :default_path_params  => [],
-    :default_query_params => [],
-    :name                 => [],
-    :parse                => [nil],
-    :schema_class         => [],
+    :default_coerce_form_params => [],
+    :default_path_params        => [],
+    :default_query_params       => [],
+    :name                       => [],
+    :parse                      => [nil],
+    :schema_class               => [],
   }
 
   it "has a set of abstract methods" do

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -82,6 +82,25 @@ describe Committee::RequestUnpacker do
     assert_equal({ "x" => "y" }, params)
   end
 
+  it "coerces form params with coerce_form_params and a schema" do
+    schema = JsonSchema::Schema.new
+    schema.properties = { "x" => JsonSchema::Schema.new }
+    schema.properties["x"].type = ["integer"]
+
+    env = {
+      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+      "rack.input"   => StringIO.new("x=1"),
+    }
+    request = Rack::Request.new(env)
+    params = Committee::RequestUnpacker.new(
+      request,
+      allow_form_params: true,
+      coerce_form_params: true,
+      schema: schema
+    ).call
+    assert_equal({ "x" => 1 }, params)
+  end
+
   it "unpacks form & query params with allow_form_params and allow_query_params" do
     env = {
       "CONTENT_TYPE" => "application/x-www-form-urlencoded",


### PR DESCRIPTION
Adds an option for type coercion for parameters encoded with
`application/x-www-form-urlencoded` like we already have for path and
query parameters. This allows specs based off this non-JSON encoding to
successfully validate against a schema. The new option is enabled by
default for OpenAPI 2.0 but not for hyper-schema for reasons of backward
compatiblity.