### PR TITLE
Require driver for "committee-stub" executable

### DIFF
--- a/bin/committee-stub
+++ b/bin/committee-stub
@@ -12,7 +12,7 @@ options, parser = bin.get_options_parser
 if $0 == __FILE__
   parser.parse!(args)
 
-  unless args.count == 1 || options[:help]
+  unless args.count == 1 || options[:help] || !options[:driver]
     puts parser.to_s
     exit
   end

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.executables   << "committee-stub"
   s.files         = Dir["{bin,lib,test}/**/*.rb"]
 
-  s.add_dependency "json_schema", "~> 0.14", ">= 0.14.1"
+  s.add_dependency "json_schema", "~> 0.14", ">= 0.14.3"
 
   # Rack 2.0+ requires Ruby >= 2.2.2 which is problematic for the test suite on
   # older Ruby versions. Check Ruby the version here and put a maximum

--- a/lib/committee/bin/committee_stub.rb
+++ b/lib/committee/bin/committee_stub.rb
@@ -25,7 +25,7 @@ module Committee
       # Gets an option parser for command line arguments.
       def get_options_parser
         options = {
-          :driver   => :hyper_schema,
+          :driver   => nil,
           :help     => false,
           :port     => 9292,
           :tolerant => false,
@@ -37,12 +37,13 @@ module Committee
           opts.separator ""
           opts.separator "Options:"
 
-          opts.on_tail("-h", "-?", "--help", "Show this message") {
-            options[:help] = true
-          }
-
+          # required
           opts.on("-d", "--driver NAME", "name of driver [open_api_2|hyper_schema]") { |name|
             options[:driver] = name.to_sym
+          }
+
+          opts.on_tail("-h", "-?", "--help", "Show this message") {
+            options[:help] = true
           }
 
           opts.on("-t", "--tolerant", "don't perform request/response validations") {


### PR DESCRIPTION
This tweaks the behavior of `committee-stub` a bit so that a driver is
now required to start it (i.e. either `hyper_schema` or `open_api_2`).

The reason to do this is that OpenAPI 2.0 will generally parse as a
valid hyper-schema, just one with no links and which doesn't do anything
useful. This leads to very confusing gotcha behavior in that you boot
the stub, nothing works, and it's not obvious what's going on.

This breaks the CLI API, but it's worth it. Fewer users should be using
this program and it's still semver-consistent with the coming major
version bump.