### PR TITLE
:bug: if no schema api, error occured in ParameterCoercer

### DIFF
--- a/lib/committee/parameter_coercer.rb
+++ b/lib/committee/parameter_coercer.rb
@@ -9,6 +9,8 @@ module Committee
 
     def call
       coerced = {}
+      return coerced unless @schema.respond_to?(:properties)
+
       @schema.properties.each do |k, s|
         original_val = @params[k]
 

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -38,6 +38,13 @@ describe Committee::Middleware::RequestValidation do
     assert_match /invalid request/i, last_response.body
   end
 
+  it "pass non-exist schema link and coerce_date_times option enable" do
+    @app = new_rack_app(coerce_date_times: true, schema: hyper_schema)
+    header "Content-Type", "application/json"
+    get "/apps", JSON.generate({})
+    assert_equal 200, last_response.status
+  end
+
   it "detects an invalid request" do
     @app = new_rack_app(schema: hyper_schema)
     header "Content-Type", "application/json"


### PR DESCRIPTION
I think we should write JSON Schema for all API :smiling_imp:
But, unfortunately there are bad people who do not write JSON Schema.
So few APIs get errors when use `coerce_date_times` . :scream:

I fix this error 😇 
