### PR TITLE
Generate an empty JSON object for object schema with no properties

### DIFF
--- a/lib/committee/response_generator.rb
+++ b/lib/committee/response_generator.rb
@@ -52,6 +52,11 @@ module Committee
         SCALAR_TYPES.each do |k, v|
           break(v) if schema.type.include?(k)
         end
+
+      # Schema is an object with no properties: just generate an empty object.
+      elsif schema.type == ["object"]
+        {}
+
       else
         raise(%{At "#{link.method} #{link.href}" "#{schema.pointer}": no } +
           %{"example" attribute and "null" } +

--- a/test/response_generator_test.rb
+++ b/test/response_generator_test.rb
@@ -79,6 +79,13 @@ describe Committee::ResponseGenerator do
     assert_equal "", Committee::ResponseGenerator.new.call(link)
   end
 
+  it "generates an empty object for an object with no fields" do
+    link = Committee::Drivers::OpenAPI2::Link.new
+    link.target_schema = JsonSchema::Schema.new
+    link.target_schema.type = ["object"]
+    assert_equal({}, Committee::ResponseGenerator.new.call(link))
+  end
+
   it "prefers an example to a built-in value" do
     link = Committee::Drivers::OpenAPI2::Link.new
     link.target_schema = JsonSchema::Schema.new


### PR DESCRIPTION
This seems like another reasonable default for stubbed response data
generation.