### PR TITLE
Embed response schema in env + more generators

### DIFF
--- a/lib/committee/middleware/stub.rb
+++ b/lib/committee/middleware/stub.rb
@@ -19,12 +19,13 @@ module Committee::Middleware
       if link
         headers = { "Content-Type" => "application/json" }
 
-        data = cache(link) do
+        data, schema = cache(link) do
           Committee::ResponseGenerator.new.call(link)
         end
 
         if @call
           request.env["committee.response"] = data
+          request.env["committee.response_schema"] = schema
           call_status, call_headers, call_body = @app.call(request.env)
 
           # a committee.suppress signal initiates a direct pass through
@@ -36,7 +37,7 @@ module Committee::Middleware
           # made, and stub normally
           headers.merge!(call_headers)
 
-          # allow allow the handler to change the data object (if unchanged, it
+          # allow the handler to change the data object (if unchanged, it
           # will be the same one that we set above)
           data = request.env["committee.response"]
         end


### PR DESCRIPTION
This one is a bit of a grab bag, but has two major goals:

* Embeds the JSON schema of a generated response in the new env key
  `committee.response_schema`. This is useful so that downstream
  applications can tweak the generated response based off of it.

* Adds a few new simple data generators: return an empty array for an
  array type, and return the first enum value for a schema with an enum.