### PR TITLE
Use `assert_nil` to avoid deprecation message

### DIFF
--- a/test/drivers/open_api_2_test.rb
+++ b/test/drivers/open_api_2_test.rb
@@ -89,8 +89,8 @@ describe Committee::Drivers::OpenAPI2 do
 
     schema = @driver.parse(schema_data)
     link = schema.routes['GET'][0][1]
-    assert_equal nil, link.status_success
-    assert_equal nil, link.target_schema
+    assert_nil link.status_success
+    assert_nil link.target_schema
   end
 
   it "refuses to parse other version of OpenAPI" do
@@ -203,7 +203,7 @@ describe Committee::Drivers::OpenAPI2::ParameterSchemaBuilder do
     }
     schema, schema_data = call(data)
 
-    assert_equal nil, schema_data
+    assert_nil schema_data
     assert_equal ["limit"], schema.properties.keys
     assert_equal [], schema.required
     assert_equal ["integer"], schema.properties["limit"].type
@@ -220,7 +220,7 @@ describe Committee::Drivers::OpenAPI2::ParameterSchemaBuilder do
     }
     schema, schema_data = call(data)
 
-    assert_equal nil, schema_data
+    assert_nil schema_data
     assert_equal ["limit"], schema.required
   end
 
@@ -238,7 +238,7 @@ describe Committee::Drivers::OpenAPI2::ParameterSchemaBuilder do
     }
     schema, schema_data = call(data)
 
-    assert_equal nil, schema_data
+    assert_nil schema_data
     assert_equal ["array"], schema.properties["tags"].type
     assert_equal({ "type" => "string" }, schema.properties["tags"].items)
   end
@@ -257,7 +257,7 @@ describe Committee::Drivers::OpenAPI2::ParameterSchemaBuilder do
     }
     schema, schema_data = call(data)
 
-    assert_equal nil, schema
+    assert_nil schema
     assert_equal({ "$ref" => "#/definitions/foo" }, schema_data)
   end
 

--- a/test/response_generator_test.rb
+++ b/test/response_generator_test.rb
@@ -89,7 +89,7 @@ describe Committee::ResponseGenerator do
 
     link.target_schema.type = ["null"]
     data, _schema = Committee::ResponseGenerator.new.call(link)
-    assert_equal nil, data
+    assert_nil data
 
     link.target_schema.type = ["string"]
     data, _schema = Committee::ResponseGenerator.new.call(link)


### PR DESCRIPTION
Some deprecation message are shown when running tests, so I fixed it.
See: https://github.com/seattlerb/minitest/pull/626
Personally I really don't like this change (I believe unit test API must be consistent), but it seems to be a determined policy in minitest.