### PR TITLE
Support recursive coerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Options:
 * `allow_query_params`: Specifies that query string parameters will be taken into consideration when doing validation (defaults to `true`).
 * `check_content_type`: Specifies that `Content-Type` should be verified according to JSON Hyper-schema definition. (defaults to `true`).
 * `coerce_date_times`: Convert the string with `"format": "date-time"` parameter to DateTime object (default to `false`).
+* `coerce_recursive`: Convert data in array object and nested object (default to `false`).
 * `coerce_form_params`: Tries to convert POST data encoded into an `application/x-www-form-urlencoded` body (where values are all strings) into concrete types required by the schema. This works for `null` (empty value), `integer` (numeric value without decimals), `number` (numeric value) and `boolean` ("true" is converted to `true` and "false" to `false`). If coercion is not possible, the original value is passed unchanged to schema validation.
 * `coerce_query_params`: The same as `coerce_form_params`, but tries to coerce `GET` parameters encoded in a request's query string.
 * `coerce_path_params`: The same as `coerce_form_params`, but tries to coerce parameters encoded in a request's URL path.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Options:
 * `allow_query_params`: Specifies that query string parameters will be taken into consideration when doing validation (defaults to `true`).
 * `check_content_type`: Specifies that `Content-Type` should be verified according to JSON Hyper-schema definition. (defaults to `true`).
 * `coerce_date_times`: Convert the string with `"format": "date-time"` parameter to DateTime object (default to `false`).
-* `coerce_recursive`: Convert data in array object and nested object (default to `false`).
+* `coerce_recursive`: Convert data in array object and nested object (default to `true`).
 * `coerce_form_params`: Tries to convert POST data encoded into an `application/x-www-form-urlencoded` body (where values are all strings) into concrete types required by the schema. This works for `null` (empty value), `integer` (numeric value without decimals), `number` (numeric value) and `boolean` ("true" is converted to `true` and "false" to `false`). If coercion is not possible, the original value is passed unchanged to schema validation.
 * `coerce_query_params`: The same as `coerce_form_params`, but tries to coerce `GET` parameters encoded in a request's query string.
 * `coerce_path_params`: The same as `coerce_form_params`, but tries to coerce parameters encoded in a request's URL path.
@@ -228,6 +228,11 @@ describe Committee::Middleware::Stub do
    end
 end
 ```
+
+## Update from 1.x to 2.x
+
+### coerce_recursive option  
+This option cause breaking changes and default `true`. if you want the behavior as before set `false`.
 
 ## Development
 

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -9,7 +9,7 @@ module Committee::Middleware
       @optimistic_json     = options.fetch(:optimistic_json, false)
       @strict              = options[:strict]
       @coerce_date_times   = options.fetch(:coerce_date_times, false)
-      @coerce_recursive = options.fetch(:coerce_recursive, false)
+      @coerce_recursive = options.fetch(:coerce_recursive, true)
 
       @coerce_form_params = options.fetch(:coerce_form_params,
         @schema.driver.default_coerce_form_params)

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -64,8 +64,8 @@ module Committee::Middleware
         validator = Committee::RequestValidator.new(link, check_content_type: @check_content_type)
         validator.call(request, request.env[@params_key])
 
-        parameter_coerce(request, link, @params_key)
-        parameter_coerce(request, link, "rack.request.query_hash") if !request.GET.nil? && !link.schema.nil?
+        parameter_coerce!(request, link, @params_key)
+        parameter_coerce!(request, link, "rack.request.query_hash") if !request.GET.nil? && !link.schema.nil?
 
         @app.call(request.env)
       elsif @strict
@@ -90,13 +90,10 @@ module Committee::Middleware
 
     private
 
-      def parameter_coerce(request, link, coerce_key)
-        request.env[coerce_key].merge!(
-            Committee::ParameterCoercer
-                .new(request.env[coerce_key], link.schema,
-                     coerce_date_times: @coerce_date_times)
-                .call
-        )
+      def parameter_coerce!(request, link, coerce_key)
+        Committee::ParameterCoercer.
+            new(request.env[coerce_key], link.schema, coerce_date_times: @coerce_date_times).
+            call!
       end
   end
 end

--- a/lib/committee/parameter_coercer.rb
+++ b/lib/committee/parameter_coercer.rb
@@ -9,19 +9,19 @@ module Committee
     end
 
     def call!
-      coercer_object!(@params, @schema)
+      coerce_object!(@params, @schema)
     end
 
     private
 
-      def coercer_object!(hash, schema)
+      def coerce_object!(hash, schema)
         return false unless schema.respond_to?(:properties)
 
         is_coerced = false
         schema.properties.each do |k, s|
           original_val = hash[k]
           unless original_val.nil?
-            new_value, is_changed = coercer_value!(original_val, s)
+            new_value, is_changed = coerce_value!(original_val, s)
             if is_changed
               hash[k] = new_value
               is_coerced = true
@@ -32,27 +32,27 @@ module Committee
         is_coerced
       end
 
-      def coercer_value!(original_val, s)
+      def coerce_value!(original_val, s)
         s.type.each do |to_type|
           if @coerce_date_times && to_type == "string" && s.format == "date-time"
             coerced_val = parse_date_time(original_val)
             return coerced_val, true if coerced_val
           end
 
-          return original_val, true if @coerce_recursive && (to_type == "array") && coercer_array_data!(original_val, s)
+          return original_val, true if @coerce_recursive && (to_type == "array") && coerce_array_data!(original_val, s)
 
-          return original_val, true if @coerce_recursive && (to_type == "object") && coercer_object!(original_val, s)
+          return original_val, true if @coerce_recursive && (to_type == "object") && coerce_object!(original_val, s)
         end
         return nil, false
       end
 
-      def coercer_array_data!(original_val, schema)
+      def coerce_array_data!(original_val, schema)
         return false unless schema.respond_to?(:items)
         return false unless original_val.is_a?(Array)
 
         is_coerced = false
         original_val.each_with_index do |d, index|
-          new_value, is_changed = coercer_value!(d, schema.items)
+          new_value, is_changed = coerce_value!(d, schema.items)
           if is_changed
             original_val[index] = new_value
             is_coerced = true

--- a/lib/committee/parameter_coercer.rb
+++ b/lib/committee/parameter_coercer.rb
@@ -5,31 +5,73 @@ module Committee
       @schema = schema
 
       @coerce_date_times = options.fetch(:coerce_date_times, false)
+      @coerce_recursive = options.fetch(:coerce_recursive, false)
     end
 
     def call
-      coerced = {}
-      return coerced unless @schema.respond_to?(:properties)
+      return {} unless @schema.respond_to?(:properties)
 
-      @schema.properties.each do |k, s|
-        original_val = @params[k]
-
-        unless original_val.nil?
-          s.type.each do |to_type|
-            if @coerce_date_times && to_type == "string" && s.format == "date-time"
-              coerce_val = parse_date_time(original_val)
-              coerced[k] = coerce_val if coerce_val
-            end
-
-            break if coerced.key?(k)
-          end
-        end
-      end
-
-      coerced
+      coercer_value(@params, @schema.properties)
     end
 
     private
+
+      def coercer_value(params, properties)
+        coerced = {}
+
+        properties.each do |k, s|
+          original_val = params[k]
+
+          unless original_val.nil?
+            s.type.each do |to_type|
+              if @coerce_date_times && to_type == "string" && s.format == "date-time"
+                coerce_val = parse_date_time(original_val)
+                coerced[k] = coerce_val if coerce_val
+              end
+
+              if (@coerce_recursive && to_type == "array") || (@coerce_recursive && to_type == "object")
+                coerce_val = coerce_data_recursive(original_val, to_type, s)
+                coerced[k] = coerce_val unless coerce_val.empty?
+              end
+
+              break if coerced.key?(k)
+            end
+          end
+        end
+
+        coerced
+      end
+
+      def coerce_data_recursive(original_val, to_type, schema)
+        return coerce_array_data(original_val, schema) if to_type == "array"
+        return coerce_object_data(original_val, schema) if to_type == "object"
+        nil # bug?
+      end
+
+      def coerce_object_data(original_val, schema)
+        return {} unless schema.respond_to?(:properties)
+
+        coerce_val = coercer_value(original_val, schema.properties)
+        original_val.merge(coerce_val)
+      end
+
+      def coerce_array_data(original_val, schema)
+        return [] unless schema.respond_to?(:items)
+        return [] unless original_val.is_a?(Array)
+
+        is_coerced = false
+        coerced_array = []
+        original_val.each do |d|
+          coerced = coercer_value(d, schema.items.properties)
+
+          is_coerced =  true unless coerced.empty?
+          coerced_array << d.merge(coerced)
+        end
+
+        return [] unless is_coerced # did't coerce
+        coerced_array
+      end
+
       def parse_date_time(original_val)
         begin
           DateTime.parse(original_val)

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -31,10 +31,7 @@ module Committee
         p = @request.POST
 
         if @coerce_form_params && @schema
-          p.merge!(Committee::StringParamsCoercer.new(
-            p,
-            @schema
-          ).call)
+          Committee::StringParamsCoercer.new(p, @schema).call!
         end
 
         p

--- a/lib/committee/string_params_coercer.rb
+++ b/lib/committee/string_params_coercer.rb
@@ -18,19 +18,19 @@ module Committee
     end
 
     def call!
-      coercer_object!(@query_hash, @schema)
+      coerce_object!(@query_hash, @schema)
     end
 
     private
 
-      def coercer_object!(hash, schema)
+      def coerce_object!(hash, schema)
         return false unless schema.respond_to?(:properties)
 
         is_coerced = false
         schema.properties.each do |k, s|
           original_val = hash[k]
           unless original_val.nil?
-            new_value, is_changed = coercer_value!(original_val, s)
+            new_value, is_changed = coerce_value!(original_val, s)
             if is_changed
               hash[k] = new_value
               is_coerced = true
@@ -41,7 +41,7 @@ module Committee
         is_coerced
       end
 
-      def coercer_value!(original_val, s)
+      def coerce_value!(original_val, s)
         unless original_val.nil?
           s.type.each do |to_type|
             case to_type
@@ -67,11 +67,11 @@ module Committee
                   return false, true
                 end
               when "array"
-                if @coerce_recursive && coercer_array_data!(original_val, s)
+                if @coerce_recursive && coerce_array_data!(original_val, s)
                   return original_val, true # change original value
                 end
               when "object"
-                if @coerce_recursive && coercer_object!(original_val, s)
+                if @coerce_recursive && coerce_object!(original_val, s)
                   return original_val, true # change original value
                 end
             end
@@ -80,13 +80,13 @@ module Committee
         return nil, false
       end
 
-      def coercer_array_data!(original_val, schema)
+      def coerce_array_data!(original_val, schema)
         return false unless schema.respond_to?(:items)
         return false unless original_val.is_a?(Array)
 
         is_coerced = false
         original_val.each_with_index do |d, index|
-          new_value, is_changed = coercer_value!(d, schema.items)
+          new_value, is_changed = coerce_value!(d, schema.items)
           if is_changed
             original_val[index] = new_value
             is_coerced = true

--- a/test/data/hyperschema/paas.json
+++ b/test/data/hyperschema/paas.json
@@ -59,6 +59,60 @@
             "string"
           ],
           "format": "date-time"
+        },
+        "nested_no_coercer_object": {
+          "type": "object",
+          "properties": {
+            "per_page": {
+              "$ref": "#/definitions/app/definitions/per_page"
+            },
+            "threshold": {
+              "$ref": "#/definitions/app/definitions/threshold"
+            }
+          }
+        },
+        "nested_coercer_object": {
+          "type": "object",
+          "properties": {
+            "update_time": {
+              "$ref": "#/definitions/app/definitions/update_time"
+            },
+            "threshold": {
+              "$ref": "#/definitions/app/definitions/threshold"
+            }
+          }
+        },
+        "array_data": {
+          "type": "object",
+          "properties": {
+            "update_time": {
+              "$ref": "#/definitions/app/definitions/update_time"
+            },
+            "per_page": {
+              "$ref": "#/definitions/app/definitions/per_page"
+            },
+            "threshold": {
+              "$ref": "#/definitions/app/definitions/threshold"
+            },
+            "nested_coercer_object": {
+              "$ref": "#/definitions/app/definitions/nested_coercer_object"
+            },
+            "nested_no_coercer_object": {
+              "$ref": "#/definitions/app/definitions/nested_no_coercer_object"
+            },
+            "nested_coercer_array": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/app/definitions/nested_coercer_object"
+              }
+            },
+            "nested_no_coercer_array": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/app/definitions/nested_no_coercer_object"
+              }
+            }
+          }
         }
       },
       "links": [
@@ -74,6 +128,12 @@
               },
               "update_time": {
                 "$ref": "#/definitions/app/definitions/update_time"
+              },
+              "array_property": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/app/definitions/array_data"
+                }
               }
             }
           },

--- a/test/data/hyperschema/paas.json
+++ b/test/data/hyperschema/paas.json
@@ -111,6 +111,18 @@
               "items": {
                 "$ref": "#/definitions/app/definitions/nested_no_coercer_object"
               }
+            },
+            "integer_array": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/app/definitions/per_page"
+              }
+            },
+            "datetime_array": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/app/definitions/update_time"
+              }
             }
           }
         }
@@ -209,6 +221,12 @@
               },
               "update_time": {
                 "$ref": "#/definitions/app/definitions/update_time"
+              },
+              "array_property": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/app/definitions/array_data"
+                }
               }
             },
             "required": ["query"]

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -109,7 +109,21 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
-  it "passes a nested object without recursive option" do
+  it "passes a nested object with coerce_recursive false" do
+    key_name = "update_time"
+    params = {
+        key_name => "2016-04-01T16:00:00.000+09:00",
+        "query" => "cloudnasium",
+        "array_property" => ARRAY_PROPERTY
+    }
+
+    @app = new_rack_app(coerce_query_params: true, coerce_date_times: true, coerce_recursive: false, schema: hyper_schema)
+
+    get "/search/apps", params
+    assert_equal 400, last_response.status # schema expect integer but we don't convert string to integer, so 400
+  end
+
+  it "passes a nested object with coerce_recursive default(true)" do
     key_name = "update_time"
     params = {
         key_name => "2016-04-01T16:00:00.000+09:00",
@@ -120,7 +134,7 @@ describe Committee::Middleware::RequestValidation do
     @app = new_rack_app(coerce_query_params: true, coerce_date_times: true, schema: hyper_schema)
 
     get "/search/apps", params
-    assert_equal 400, last_response.status # schema expect integer but we don't convert string to integer, so 400
+    assert_equal 200, last_response.status # schema expect integer but we don't convert string to integer, so 400
   end
 
   it "passes given a nested datetime and with coerce_recursive=true and coerce_date_times=true on POST endpoint" do
@@ -194,7 +208,7 @@ describe Committee::Middleware::RequestValidation do
       [200, {}, []]
     }
 
-    @app = new_rack_app_with_lambda(check_parameter, coerce_date_times: true, schema: hyper_schema)
+    @app = new_rack_app_with_lambda(check_parameter, coerce_date_times: true, coerce_recursive: false, schema: hyper_schema)
 
     header "Content-Type", "application/json"
     post "/apps", JSON.generate(params)

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -7,6 +7,50 @@ describe Committee::Middleware::RequestValidation do
     @app
   end
 
+  ARRAY_PROPERTY = [
+      {
+          "update_time" => "2016-04-01T16:00:00.000+09:00",
+          "per_page" => 1,
+          "nested_coercer_object" => {
+              "update_time" => "2016-04-01T16:00:00.000+09:00",
+              "threshold" => 1.5
+          },
+          "nested_no_coercer_object" => {
+              "per_page" => 1,
+              "threshold" => 1.5
+          },
+          "nested_coercer_array" => [
+              {
+                  "update_time" => "2016-04-01T16:00:00.000+09:00",
+                  "threshold" => 1.5
+              }
+          ],
+          "nested_no_coercer_array" => [
+              {
+                  "per_page" => 1,
+                  "threshold" => 1.5
+              }
+          ],
+          "integer_array" => [
+              1, 2, 3
+          ],
+          "datetime_array" => [
+              "2016-04-01T16:00:00.000+09:00",
+              "2016-04-01T17:00:00.000+09:00",
+              "2016-04-01T18:00:00.000+09:00"
+          ]
+      },
+      {
+          "update_time" => "2016-04-01T16:00:00.000+09:00",
+          "per_page" => 1,
+          "threshold" => 1.5
+      },
+      {
+          "threshold" => 1.5,
+          "per_page" => 1
+      }
+  ]
+
   it "passes through a valid request" do
     @app = new_rack_app(schema: hyper_schema)
     params = {
@@ -35,18 +79,148 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
-  it "passes given a datetime and with coerce_date_times enabled on POST endpoint" do
+  it "passes a nested object with recursive option" do
     key_name = "update_time"
     params = {
-        key_name => "2016-04-01T16:00:00.000+09:00"
+        key_name => "2016-04-01T16:00:00.000+09:00",
+        "query" => "cloudnasium",
+        "array_property" => ARRAY_PROPERTY
     }
 
     check_parameter = lambda { |env|
+      hash = env['rack.request.query_hash']
+      assert_equal DateTime, hash['array_property'].first['update_time'].class
+      assert_equal 1, hash['array_property'].first['per_page']
+      assert_equal DateTime, hash['array_property'].first['nested_coercer_object']['update_time'].class
+      assert_equal 1, hash['array_property'].first['nested_no_coercer_object']['per_page']
+      assert_equal 2, hash['array_property'].first['integer_array'][1]
+      assert_equal DateTime, hash['array_property'].first['datetime_array'][0].class
+      assert_equal DateTime, hash[key_name].class
+      [200, {}, []]
+    }
+
+    @app = new_rack_app_with_lambda(check_parameter,
+                                    coerce_query_params: true,
+                                    coerce_recursive: true,
+                                    coerce_date_times: true,
+                                    schema: hyper_schema)
+
+    get "/search/apps", params
+    assert_equal 200, last_response.status
+  end
+
+  it "passes a nested object without recursive option" do
+    key_name = "update_time"
+    params = {
+        key_name => "2016-04-01T16:00:00.000+09:00",
+        "query" => "cloudnasium",
+        "array_property" => ARRAY_PROPERTY
+    }
+
+    @app = new_rack_app(coerce_query_params: true, coerce_date_times: true, schema: hyper_schema)
+
+    get "/search/apps", params
+    assert_equal 400, last_response.status # schema expect integer but we don't convert string to integer, so 400
+  end
+
+  it "passes given a nested datetime and with coerce_recursive=true and coerce_date_times=true on POST endpoint" do
+    key_name = "update_time"
+    params = {
+        key_name => "2016-04-01T16:00:00.000+09:00",
+        "array_property" => ARRAY_PROPERTY
+    }
+
+    check_parameter = lambda { |env|
+      hash = env['committee.params']
+      assert_equal DateTime, hash['array_property'].first['update_time'].class
+      assert_equal 1, hash['array_property'].first['per_page']
+      assert_equal DateTime, hash['array_property'].first['nested_coercer_object']['update_time'].class
+      assert_equal 1, hash['array_property'].first['nested_no_coercer_object']['per_page']
+      assert_equal 2, hash['array_property'].first['integer_array'][1]
+      assert_equal DateTime, hash['array_property'].first['datetime_array'][0].class
+      assert_equal DateTime, env['committee.params'][key_name].class
+      [200, {}, []]
+    }
+
+    @app = new_rack_app_with_lambda(check_parameter, coerce_date_times: true, coerce_recursive: true, schema: hyper_schema)
+
+    header "Content-Type", "application/json"
+    post "/apps", JSON.generate(params)
+    assert_equal 200, last_response.status
+  end
+
+  it "passes given a nested datetime and with coerce_recursive=true and coerce_date_times=true on POST endpoint" do
+    key_name = "update_time"
+    params = {
+        key_name => "2016-04-01T16:00:00.000+09:00",
+        "array_property" => ARRAY_PROPERTY
+    }
+
+    check_parameter = lambda { |env|
+      hash = env['committee.params']
+      assert_equal String, hash['array_property'].first['update_time'].class
+      assert_equal 1, hash['array_property'].first['per_page']
+      assert_equal String, hash['array_property'].first['nested_coercer_object']['update_time'].class
+      assert_equal 1, hash['array_property'].first['nested_no_coercer_object']['per_page']
+      assert_equal 2, hash['array_property'].first['integer_array'][1]
+      assert_equal String, hash['array_property'].first['datetime_array'][0].class
+      assert_equal String, env['committee.params'][key_name].class
+      [200, {}, []]
+    }
+
+    @app = new_rack_app_with_lambda(check_parameter, schema: hyper_schema)
+
+    header "Content-Type", "application/json"
+    post "/apps", JSON.generate(params)
+    assert_equal 200, last_response.status
+  end
+
+  it "passes given a nested datetime and with coerce_recursive=false and coerce_date_times=true on POST endpoint" do
+    key_name = "update_time"
+    params = {
+        key_name => "2016-04-01T16:00:00.000+09:00",
+        "array_property" => ARRAY_PROPERTY
+    }
+
+    check_parameter = lambda { |env|
+      hash = env['committee.params']
+      assert_equal String, hash['array_property'].first['update_time'].class
+      assert_equal 1, hash['array_property'].first['per_page']
+      assert_equal String, hash['array_property'].first['nested_coercer_object']['update_time'].class
+      assert_equal 1, hash['array_property'].first['nested_no_coercer_object']['per_page']
+      assert_equal 2, hash['array_property'].first['integer_array'][1]
+      assert_equal String, hash['array_property'].first['datetime_array'][0].class
       assert_equal DateTime, env['committee.params'][key_name].class
       [200, {}, []]
     }
 
     @app = new_rack_app_with_lambda(check_parameter, coerce_date_times: true, schema: hyper_schema)
+
+    header "Content-Type", "application/json"
+    post "/apps", JSON.generate(params)
+    assert_equal 200, last_response.status
+  end
+
+  it "passes given a nested datetime and with coerce_recursive=false and coerce_date_times=false on POST endpoint" do
+    key_name = "update_time"
+    params = {
+        key_name => "2016-04-01T16:00:00.000+09:00",
+        "array_property" => ARRAY_PROPERTY
+    }
+
+    check_parameter = lambda { |env|
+      hash = env['committee.params']
+      assert_equal String, hash['array_property'].first['update_time'].class
+      assert_equal 1, hash['array_property'].first['per_page']
+      assert_equal String, hash['array_property'].first['nested_coercer_object']['update_time'].class
+      assert_equal 1, hash['array_property'].first['nested_no_coercer_object']['per_page']
+      assert_equal 2, hash['array_property'].first['integer_array'][1]
+      assert_equal String, hash['array_property'].first['datetime_array'][0].class
+      assert_equal String, env['committee.params'][key_name].class
+      [200, {}, []]
+    }
+
+    @app = new_rack_app_with_lambda(check_parameter, schema: hyper_schema)
 
     header "Content-Type", "application/json"
     post "/apps", JSON.generate(params)
@@ -153,7 +327,12 @@ describe Committee::Middleware::RequestValidation do
   end
 
   it "passes through a valid request for OpenAPI" do
-    @app = new_rack_app(schema: open_api_2_schema)
+    check_parameter = lambda { |env|
+      assert_equal 3, env['rack.request.query_hash']['limit']
+      [200, {}, []]
+    }
+
+    @app = new_rack_app_with_lambda(check_parameter, schema: open_api_2_schema)
     get "/api/pets?limit=3"
     assert_equal 200, last_response.status
   end

--- a/test/parameter_coercer_test.rb
+++ b/test/parameter_coercer_test.rb
@@ -24,6 +24,72 @@ describe Committee::ParameterCoercer do
     assert_nil converted_params["update_time"]
   end
 
+  it "pass array property" do
+    params = {
+        "array_property" => [
+            {
+                "update_time" => "2016-04-01T16:00:00.000+09:00",
+                "per_page" => 1,
+                "nested_coercer_object" => {
+                    "update_time" => "2016-04-01T16:00:00.000+09:00",
+                    "threshold" => 1.5
+                },
+                "nested_no_coercer_object" => {
+                    "per_page" => 1,
+                    "threshold" => 1.5
+                },
+                "nested_coercer_array" => [
+                    {
+                        "update_time" => "2016-04-01T16:00:00.000+09:00",
+                        "threshold" => 1.5
+                    }
+                ],
+                "nested_no_coercer_array" => [
+                    {
+                        "per_page" => 1,
+                        "threshold" => 1.5
+                    }
+                ]
+            },
+            {
+                "update_time" => "2016-04-01T16:00:00.000+09:00",
+                "per_page" => 1,
+                "threshold" => 1.5
+            },
+            {
+                "threshold" => 1.5,
+                "per_page" => 1
+            }
+        ],
+    }
+    converted_params = call(params, coerce_date_times: true, coerce_recursive: true)
+
+    first_data = converted_params["array_property"][0]
+    assert_kind_of DateTime, first_data["update_time"]
+    assert_kind_of Integer, first_data["per_page"]
+
+    second_data = converted_params["array_property"][1]
+    assert_kind_of DateTime, second_data["update_time"]
+    assert_kind_of Integer, second_data["per_page"]
+    assert_kind_of Float, second_data["threshold"]
+
+    third_data = converted_params["array_property"][1]
+    assert_kind_of Integer, third_data["per_page"]
+    assert_kind_of Float, third_data["threshold"]
+
+    assert_kind_of DateTime, first_data["nested_coercer_object"]["update_time"]
+    assert_kind_of Float, first_data["nested_coercer_object"]["threshold"]
+
+    assert_kind_of Integer, first_data["nested_no_coercer_object"]["per_page"]
+    assert_kind_of Float, first_data["nested_no_coercer_object"]["threshold"]
+
+    assert_kind_of DateTime, first_data["nested_coercer_array"].first["update_time"]
+    assert_kind_of Float, first_data["nested_coercer_array"].first["threshold"]
+
+    assert_kind_of Integer, first_data["nested_no_coercer_array"].first["per_page"]
+    assert_kind_of Float, first_data["nested_no_coercer_array"].first["threshold"]
+  end
+
   private
 
   def call(params, options={})

--- a/test/string_params_coercer_test.rb
+++ b/test/string_params_coercer_test.rb
@@ -9,65 +9,122 @@ describe Committee::StringParamsCoercer do
   end
 
   it "doesn't coerce params not in the schema" do
-    data = {"owner" => "admin"}
-    assert_equal({}, call(data))
+    check_convert("onwer", "admin", "admin")
   end
 
   it "skips values for string param" do
-    data = {"name" => "foo"}
-    assert_equal({}, call(data))
+    check_convert("name", "foo", "foo")
   end
 
   it "coerces valid values for boolean param" do
-    data = {"deleted" => "true"}
-    assert_equal({"deleted" => true}, call(data))
-    data = {"deleted" => "false"}
-    assert_equal({"deleted" => false}, call(data))
-    data = {"deleted" => "1"}
-    assert_equal({"deleted" => true}, call(data))
-    data = {"deleted" => "0"}
-    assert_equal({"deleted" => false}, call(data))
+    check_convert("deleted", "true", true)
+    check_convert("deleted", "false", false)
+    check_convert("deleted", "1", true)
+    check_convert("deleted", "0", false)
   end
 
   it "skips invalid values for boolean param" do
-    data = {"deleted" => "foo"}
-    assert_equal({}, call(data))
+    check_convert("deleted", "foo", "foo")
   end
 
   it "coerces valid values for integer param" do
-    data = {"per_page" => "3"}
-    assert_equal({"per_page" => 3}, call(data))
+    check_convert("per_page", "3", 3)
   end
 
   it "skips invalid values for integer param" do
-    data = {"per_page" => "3.5"}
-    assert_equal({}, call(data))
-    data = {"per_page" => "false"}
-    assert_equal({}, call(data))
-    data = {"per_page" => ""}
-    assert_equal({}, call(data))
+    check_convert("per_page", "3.5", "3.5")
+    check_convert("per_page", "false", "false")
+    check_convert("per_page", "", "")
   end
 
   it "coerces valid values for number param" do
-    data = {"threshold" => "3"}
-    assert_equal({"threshold" => 3.0}, call(data))
-    data = {"threshold" => "3.5"}
-    assert_equal({"threshold" => 3.5}, call(data))
+    check_convert("threshold", "3", 3.0)
+    check_convert("threshold", "3.5", 3.5)
   end
 
   it "skips invalid values for number param" do
-    data = {"threshold" => "false"}
-    assert_equal({}, call(data))
+    check_convert("threshold", "false", "false")
   end
 
   it "coerces valid values for null param" do
-    data = {"threshold" => ""}
-    assert_equal({"threshold" => nil}, call(data))
+    check_convert("threshold", "", nil)
+  end
+
+  it "pass array property" do
+    params = {
+        "array_property" => [
+            {
+                "update_time" => "2016-04-01T16:00:00.000+09:00",
+                "per_page" => "1",
+                "nested_coercer_object" => {
+                    "update_time" => "2016-04-01T16:00:00.000+09:00",
+                    "threshold" => "1.5"
+                },
+                "nested_no_coercer_object" => {
+                    "per_page" => "1",
+                    "threshold" => "1.5"
+                },
+                "nested_coercer_array" => [
+                    {
+                        "update_time" => "2016-04-01T16:00:00.000+09:00",
+                        "threshold" => "1.5"
+                    }
+                ],
+                "nested_no_coercer_array" => [
+                    {
+                        "per_page" => "1",
+                        "threshold" => "1.5"
+                    }
+                ]
+            },
+            {
+                "update_time" => "2016-04-01T16:00:00.000+09:00",
+                "per_page" => "1",
+                "threshold" => "1.5"
+            },
+            {
+                "threshold" => "1.5",
+                "per_page" => "1"
+            }
+        ],
+    }
+    call(params, coerce_recursive: true)
+
+    first_data = params["array_property"][0]
+    assert_kind_of String, first_data["update_time"]
+    assert_kind_of Integer, first_data["per_page"]
+
+    second_data = params["array_property"][1]
+    assert_kind_of String, second_data["update_time"]
+    assert_kind_of Integer, second_data["per_page"]
+    assert_kind_of Float, second_data["threshold"]
+
+    third_data = params["array_property"][1]
+    assert_kind_of Integer, third_data["per_page"]
+    assert_kind_of Float, third_data["threshold"]
+
+    assert_kind_of String, first_data["nested_coercer_object"]["update_time"]
+    assert_kind_of Float, first_data["nested_coercer_object"]["threshold"]
+
+    assert_kind_of Integer, first_data["nested_no_coercer_object"]["per_page"]
+    assert_kind_of Float, first_data["nested_no_coercer_object"]["threshold"]
+
+    assert_kind_of String, first_data["nested_coercer_array"].first["update_time"]
+    assert_kind_of Float, first_data["nested_coercer_array"].first["threshold"]
+
+    assert_kind_of Integer, first_data["nested_no_coercer_array"].first["per_page"]
+    assert_kind_of Float, first_data["nested_no_coercer_array"].first["threshold"]
   end
 
   private
 
-  def call(data)
-    Committee::StringParamsCoercer.new(data, @link.schema).call
+  def check_convert(key, before_value, after_value)
+    data = {key => before_value}
+    call(data)
+    assert_equal(data[key], after_value)
+  end
+
+  def call(data, options={})
+    Committee::StringParamsCoercer.new(data, @link.schema, options).call!
   end
 end


### PR DESCRIPTION
`coerce_date_times` option didn't work recursive object and array object so I did fix.

For example, the commitee didn't convert string object to datetime object when `coerce_date_times` is true.

```
{
  "array_property" => [
  {
    "update_time" => "2016-04-01T16:00:00.000+09:00",
  }
}
```

ParameterCoercer convert top level(?) keys only.
So I implement recursive convert.

we need fix when this option enable
- [x] coerce_query_params
- [x] coerce_form_params