### PR TITLE
Validate header parameters

### DIFF
--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -5,6 +5,7 @@ module Committee::Middleware
 
       @error_class = options.fetch(:error_class, Committee::ValidationError)
       @params_key = options[:params_key] || "committee.params"
+      @headers_key = options[:headers_key] || "committee.headers"
       @raise = options[:raise]
       @schema = get_schema(options[:schema] ||
         raise(ArgumentError, "Committee: need option `schema`"))

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -6,6 +6,7 @@ module Committee::Middleware
       @allow_form_params   = options.fetch(:allow_form_params, true)
       @allow_query_params  = options.fetch(:allow_query_params, true)
       @check_content_type  = options.fetch(:check_content_type, true)
+      @check_header        = options.fetch(:check_header, true)
       @optimistic_json     = options.fetch(:optimistic_json, false)
       @strict              = options[:strict]
       @coerce_date_times   = options.fetch(:coerce_date_times, false)
@@ -39,7 +40,7 @@ module Committee::Middleware
         end
       end
 
-      request.env[@params_key] = Committee::RequestUnpacker.new(
+      request.env[@params_key], request.env[@headers_key] = Committee::RequestUnpacker.new(
         request,
         allow_form_params:  @allow_form_params,
         allow_query_params: @allow_query_params,
@@ -51,8 +52,8 @@ module Committee::Middleware
       request.env[@params_key].merge!(param_matches) if param_matches
 
       if link
-        validator = Committee::RequestValidator.new(link, check_content_type: @check_content_type)
-        validator.call(request, request.env[@params_key])
+        validator = Committee::RequestValidator.new(link, check_content_type: @check_content_type, check_header: @check_header)
+        validator.call(request, request.env[@params_key], request.env[@headers_key])
 
         parameter_coerce!(request, link, @params_key)
         parameter_coerce!(request, link, "rack.request.query_hash") if !request.GET.nil? && !link.schema.nil?

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -40,9 +40,9 @@ module Committee
       end
 
       if @allow_query_params
-        indifferent_params(@request.GET).merge(params)
+        [indifferent_params(@request.GET).merge(params), headers]
       else
-        params
+        [params, headers]
       end
     end
 
@@ -85,6 +85,15 @@ module Committee
       # if request body is empty, we just have empty params
       else
         nil
+      end
+    end
+
+    def headers
+      env = @request.env
+      env.keys.grep(/HTTP_/).inject({}) do |headers, key|
+        headerized_key = key.gsub(/^HTTP_/, '').gsub(/_/, '-')
+        headers[headerized_key] = env[key]
+        headers
       end
     end
   end

--- a/test/data/openapi2/petstore-expanded.json
+++ b/test/data/openapi2/petstore-expanded.json
@@ -50,6 +50,13 @@
             "required": false,
             "type": "integer",
             "format": "int32"
+          },
+          {
+            "name": "AUTH-TOKEN",
+            "in": "header",
+            "description": "authorization token",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {

--- a/test/drivers/open_api_2_test.rb
+++ b/test/drivers/open_api_2_test.rb
@@ -298,3 +298,26 @@ describe Committee::Drivers::OpenAPI2::ParameterSchemaBuilder do
     Committee::Drivers::OpenAPI2::ParameterSchemaBuilder.new(data).call
   end
 end
+
+describe Committee::Drivers::OpenAPI2::HeaderSchemaBuilder do
+  it "returns schema data for header" do
+    data = {
+      "parameters" => [
+        {
+          "name" => "AUTH_TOKEN",
+          "type" => "string",
+          "in" => "header",
+        }
+      ]
+    }
+    schema = call(data)
+
+    assert_equal ["string"], schema.properties["AUTH_TOKEN"].type
+  end
+
+  private
+
+  def call(data)
+    Committee::Drivers::OpenAPI2::HeaderSchemaBuilder.new(data).call
+  end
+end

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -347,13 +347,13 @@ describe Committee::Middleware::RequestValidation do
     }
 
     @app = new_rack_app_with_lambda(check_parameter, schema: open_api_2_schema)
-    get "/api/pets?limit=3"
+    get "/api/pets?limit=3", nil, { "HTTP_AUTH_TOKEN" => "xxx" }
     assert_equal 200, last_response.status
   end
 
   it "detects an invalid request for OpenAPI" do
     @app = new_rack_app(schema: open_api_2_schema)
-    get "/api/pets?limit=foo"
+    get "/api/pets?limit=foo", nil, { "HTTP_AUTH_TOKEN" => "xxx" }
     assert_equal 400, last_response.status
     assert_match /invalid request/i, last_response.body
   end

--- a/test/parameter_coercer_test.rb
+++ b/test/parameter_coercer_test.rb
@@ -7,7 +7,7 @@ describe Committee::ParameterCoercer do
     @schema = JsonSchema.parse!(hyper_schema_data)
     @schema.expand_references!
     # POST /apps/:id
-    @link = @link = @schema.properties["app"].links[0]
+    @link = @schema.properties["app"].links[0]
   end
 
   it "pass datetime string" do

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -9,7 +9,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new('{"x":"y"}'),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request).call
+    params, _ = Committee::RequestUnpacker.new(request).call
     assert_equal({ "x" => "y" }, params)
   end
 
@@ -18,7 +18,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new('{"x":"y"}'),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request).call
+    params, _ = Committee::RequestUnpacker.new(request).call
     assert_equal({ "x" => "y" }, params)
   end
 
@@ -28,7 +28,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new('{"x":"y"}'),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request).call
+    params, _ = Committee::RequestUnpacker.new(request).call
     assert_equal({}, params)
   end
 
@@ -38,7 +38,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new('{"x":"y"}'),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request, optimistic_json: true).call
+    params, _ = Committee::RequestUnpacker.new(request, optimistic_json: true).call
     assert_equal({ "x" => "y" }, params)
   end
 
@@ -48,7 +48,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new('x=y&foo=42'),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request, optimistic_json: true).call
+    params, _ = Committee::RequestUnpacker.new(request, optimistic_json: true).call
     assert_equal({}, params)
   end
 
@@ -58,7 +58,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new(""),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request).call
+    params, _ = Committee::RequestUnpacker.new(request).call
     assert_equal({}, params)
   end
 
@@ -68,7 +68,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new("x=y"),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request).call
+    params, _ = Committee::RequestUnpacker.new(request).call
     assert_equal({}, params)
   end
 
@@ -78,7 +78,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new("x=y"),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request, allow_form_params: true).call
+    params, _ = Committee::RequestUnpacker.new(request, allow_form_params: true).call
     assert_equal({ "x" => "y" }, params)
   end
 
@@ -92,7 +92,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new("x=1"),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(
+    params, _ = Committee::RequestUnpacker.new(
       request,
       allow_form_params: true,
       coerce_form_params: true,
@@ -108,7 +108,7 @@ describe Committee::RequestUnpacker do
       "QUERY_STRING" => "a=b"
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request, allow_form_params: true, allow_query_params: true).call
+    params, _ = Committee::RequestUnpacker.new(request, allow_form_params: true, allow_query_params: true).call
     assert_equal({ "x" => "y", "a" => "b" }, params)
   end
 
@@ -118,7 +118,7 @@ describe Committee::RequestUnpacker do
       "QUERY_STRING" => "a=b"
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request, allow_query_params: true).call
+    params, _ = Committee::RequestUnpacker.new(request, allow_query_params: true).call
     assert_equal({ "a" => "b" }, params)
   end
 
@@ -139,7 +139,7 @@ describe Committee::RequestUnpacker do
       "rack.input"   => StringIO.new('{"x":"y"}'),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request).call
+    params, _ = Committee::RequestUnpacker.new(request).call
     assert_equal({}, params)
   end
 
@@ -149,7 +149,17 @@ describe Committee::RequestUnpacker do
       "rack.input" => StringIO.new('{"x":[]}'),
     }
     request = Rack::Request.new(env)
-    params = Committee::RequestUnpacker.new(request).call
+    params, _ = Committee::RequestUnpacker.new(request).call
     assert_equal({ "x" => [] }, params)
+  end
+
+  it "unpacks http header" do
+    env = {
+      "HTTP_FOO_BAR" => "some header value",
+      "rack.input"   => StringIO.new(""),
+    }
+    request = Rack::Request.new(env)
+    _, headers = Committee::RequestUnpacker.new(request, { allow_header_params: true }).call
+    assert_equal({ "FOO-BAR" => "some header value" }, headers)
   end
 end

--- a/test/request_validator_test.rb
+++ b/test/request_validator_test.rb
@@ -8,7 +8,7 @@ describe Committee::RequestValidator do
       @schema = JsonSchema.parse!(hyper_schema_data)
       @schema.expand_references!
       # POST /apps/:id
-      @link = @link = @schema.properties["app"].links[0]
+      @link = @schema.properties["app"].links[0]
       @request = Rack::Request.new({
                                      "CONTENT_TYPE"   => "application/json",
                                      "rack.input"     => StringIO.new("{}"),
@@ -65,7 +65,7 @@ describe Committee::RequestValidator do
 
     it "detects an missing parameter in GET requests" do
       # GET /apps/search?query=...
-      @link = @link = @schema.properties["app"].links[5]
+      @link = @schema.properties["app"].links[5]
       @request = Rack::Request.new({})
       e = assert_raises(Committee::InvalidRequest) do
         call({})

--- a/test/request_validator_test.rb
+++ b/test/request_validator_test.rb
@@ -3,102 +3,147 @@ require_relative "test_helper"
 require "stringio"
 
 describe Committee::RequestValidator do
-  before do
-    @schema = JsonSchema.parse!(hyper_schema_data)
-    @schema.expand_references!
-    # POST /apps/:id
-    @link = @link = @schema.properties["app"].links[0]
-    @request = Rack::Request.new({
-      "CONTENT_TYPE"   => "application/json",
-      "rack.input"     => StringIO.new("{}"),
-      "REQUEST_METHOD" => "POST"
-    })
-  end
+  describe 'HyperSchema' do
+    before do
+      @schema = JsonSchema.parse!(hyper_schema_data)
+      @schema.expand_references!
+      # POST /apps/:id
+      @link = @link = @schema.properties["app"].links[0]
+      @request = Rack::Request.new({
+                                     "CONTENT_TYPE"   => "application/json",
+                                     "rack.input"     => StringIO.new("{}"),
+                                     "REQUEST_METHOD" => "POST"
+                                   })
+    end
 
-  it "passes through a valid request with Content-Type options" do
-    @headers = { "Content-Type" => "application/json; charset=utf-8" }
-    call({})
-  end
-
-  it "passes through a valid request" do
-    data = {
-      "name" => "heroku-api",
-    }
-    call(data)
-  end
-
-  it "passes through a valid request with Content-Type options" do
-    @request =
-      Rack::Request.new({
-      "CONTENT_TYPE" => "application/json; charset=utf-8",
-      "rack.input"   => StringIO.new("{}"),
-    })
-    data = {
-      "name" => "heroku-api",
-    }
-    call(data)
-  end
-
-  it "detects an invalid request Content-Type" do
-    e = assert_raises(Committee::InvalidRequest) {
-      @request =
-        Rack::Request.new({
-          "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-          "rack.input"   => StringIO.new("{}"),
-        })
-      call({})
-    }
-    message =
-      %{"Content-Type" request header must be set to "application/json".}
-    assert_equal message, e.message
-  end
-
-  it "allows skipping content_type check" do
-    @request =
-      Rack::Request.new({
-        "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-        "rack.input"   => StringIO.new("{}"),
-      })
-    call({}, check_content_type: false)
-  end
-
-  it "detects an missing parameter in GET requests" do
-    # GET /apps/search?query=...
-    @link = @link = @schema.properties["app"].links[5]
-    @request = Rack::Request.new({})
-    e = assert_raises(Committee::InvalidRequest) do
+    it "passes through a valid request with Content-Type options" do
+      @headers = { "Content-Type" => "application/json; charset=utf-8" }
       call({})
     end
-    message =
-      %{Invalid request.\n\n#: failed schema #/definitions/app/links/5/schema: "query" wasn't supplied.}
-    assert_equal message, e.message
-  end
 
-  it "allows an invalid Content-Type with an empty body" do
-    @request =
-      Rack::Request.new({
-        "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-        "rack.input"   => StringIO.new(""),
-      })
-    call({})
-  end
-
-  it "detects a parameter of the wrong pattern" do
-    data = {
-      "name" => "%@!"
-    }
-    e = assert_raises(Committee::InvalidRequest) do
+    it "passes through a valid request" do
+      data = {
+        "name" => "heroku-api",
+      }
       call(data)
     end
-    message = %{Invalid request.\n\n#/name: failed schema #/definitions/app/links/0/schema/properties/name: %@! does not match /^[a-z][a-z0-9-]{3,30}$/.}
-    assert_equal message, e.message
+
+    it "passes through a valid request with Content-Type options" do
+      @request =
+        Rack::Request.new({
+                            "CONTENT_TYPE" => "application/json; charset=utf-8",
+                            "rack.input"   => StringIO.new("{}"),
+                          })
+      data = {
+        "name" => "heroku-api",
+      }
+      call(data)
+    end
+
+    it "detects an invalid request Content-Type" do
+      e = assert_raises(Committee::InvalidRequest) {
+        @request =
+          Rack::Request.new({
+                              "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+                              "rack.input"   => StringIO.new("{}"),
+                            })
+        call({})
+      }
+      message =
+        %{"Content-Type" request header must be set to "application/json".}
+      assert_equal message, e.message
+    end
+
+    it "allows skipping content_type check" do
+      @request =
+        Rack::Request.new({
+                            "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+                            "rack.input"   => StringIO.new("{}"),
+                          })
+      call({}, {}, check_content_type: false)
+    end
+
+    it "detects an missing parameter in GET requests" do
+      # GET /apps/search?query=...
+      @link = @link = @schema.properties["app"].links[5]
+      @request = Rack::Request.new({})
+      e = assert_raises(Committee::InvalidRequest) do
+        call({})
+      end
+      message =
+        %{Invalid request.\n\n#: failed schema #/definitions/app/links/5/schema: "query" wasn't supplied.}
+      assert_equal message, e.message
+    end
+
+    it "allows an invalid Content-Type with an empty body" do
+      @request =
+        Rack::Request.new({
+                            "CONTENT_TYPE" => "application/x-www-form-urlencoded",
+                            "rack.input"   => StringIO.new(""),
+                          })
+      call({})
+    end
+
+    it "detects a parameter of the wrong pattern" do
+      data = {
+        "name" => "%@!"
+      }
+      e = assert_raises(Committee::InvalidRequest) do
+        call(data)
+      end
+      message = %{Invalid request.\n\n#/name: failed schema #/definitions/app/links/0/schema/properties/name: %@! does not match /^[a-z][a-z0-9-]{3,30}$/.}
+      assert_equal message, e.message
+    end
+
+    private
+
+    def call(data, headers={}, options={})
+      # hyper-schema link should be dropped into driver wrapper before it's used
+      link = Committee::Drivers::HyperSchema::Link.new(@link)
+      Committee::RequestValidator.new(link, options).call(@request, data, headers)
+    end
   end
 
-  private
+  describe 'OpenAPI 2' do
+    before do
+      @schema = open_api_2_schema
+      @link = @schema.routes['GET'][0][1]
+      @request = Rack::Request.new({
+                                     "CONTENT_TYPE"   => "application/json",
+                                     "rack.input"     => StringIO.new("{}"),
+                                     "REQUEST_METHOD" => "POST"
+                                   })
+    end
 
-  def call(data, options={})
-    # hyper-schema link should be dropped into driver wrapper before it's used
-    link = Committee::Drivers::HyperSchema::Link.new(@link)
-    Committee::RequestValidator.new(link, options).call(@request, data)
+
+    it "passes through a valid request" do
+      headers = {
+        "AUTH-TOKEN" => "xxx"
+      }
+      call({}, headers)
+    end
+
+    it "detects an missing header parameter in GET requests" do
+      @link = @schema.routes['GET'][0][1]
+      @request = Rack::Request.new({})
+      e = assert_raises(Committee::InvalidRequest) do
+        call({}, {})
+      end
+      message = %{Invalid request.\n\n#: failed schema : "AUTH-TOKEN" wasn't supplied.}
+      assert_equal message, e.message
+    end
+
+    it "allows skipping header schema check" do
+      @link = @schema.routes['GET'][0][1]
+      @request = Rack::Request.new({})
+      call({}, {}, { check_header: false })
+    end
+
+    private
+
+    def call(data, headers={}, options={})
+      # hyper-schema link should be dropped into driver wrapper before it's used
+      Committee::RequestValidator.new(@link, options).call(@request, data, headers)
+    end
   end
 end

--- a/test/string_params_coercer_test.rb
+++ b/test/string_params_coercer_test.rb
@@ -5,7 +5,7 @@ describe Committee::StringParamsCoercer do
     @schema = JsonSchema.parse!(hyper_schema_data)
     @schema.expand_references!
     # GET /search/apps
-    @link = @link = @schema.properties["app"].links[5]
+    @link = @schema.properties["app"].links[5]
   end
 
   it "doesn't coerce params not in the schema" do


### PR DESCRIPTION
On current version of committee, parameters in header is not validated when parameter is defined in header on OpenAPI 2.0 format.

So the following OpenAPI description is not working because current version does't extract and validate header values.
```yaml 
...
properties:
  name:
    type: string
    in: header
...
```

This pull request solve them.

* If allow_header_params is enabled, header values is extracted as parameter.
* On OpenAPI driver, header parameter is uppercased because we treat header key as CGI header values, that is uppercased and converted hyphen to underscore.