### PR TITLE
Fix HTTP Status Code load from OpenAPI 2.0 YAML

### DIFF
--- a/lib/committee/drivers/open_api_2.rb
+++ b/lib/committee/drivers/open_api_2.rb
@@ -190,9 +190,9 @@ module Committee::Drivers
     ].map(&:to_s).freeze
 
     def find_best_fit_response(link_data)
-      if response_data = link_data["responses"]["200"]
+      if response_data = link_data["responses"]["200"] || response_data = link_data["responses"][200]
         [200, response_data]
-      elsif response_data = link_data["responses"]["201"]
+      elsif response_data = link_data["responses"]["201"] || response_data = link_data["responses"][201]
         [201, response_data]
       else
         # Sort responses so that we can try to prefer any 3-digit status code.


### PR DESCRIPTION
I can't use `HTTP Status Code` integer load from OpenAPI 2.0 YAML.
But, I can use `HTTP Status Code` string load from OpenAPI 2.0 YAML.

# Example

## 🆗 

```petstore.yaml
responses:
        '200':
          description: pet response
          schema:
            type: array
            items:
              $ref: "#/definitions/Pet"
```

## 🆖 

```petstore.yaml
responses:
        200:
          description: pet response
          schema:
            type: array
            items:
              $ref: "#/definitions/Pet"
```

# OpenAPI 2.0 Document

https://swagger.io/docs/specification/2-0/describing-responses/
