### PR TITLE
bundled executable file path does not match installed script file path

### DIFF
--- a/bin/committee-stub
+++ b/bin/committee-stub
@@ -13,10 +13,9 @@ parser.parse!(args)
 
 if options[:help] || !options[:driver]
   puts parser.to_s
-  exit
+else
+  driver = Committee::Drivers.driver_from_name(options[:driver])
+  schema = driver.parse(::YAML.load(File.read(args[0])))
+
+  Rack::Server.start(app: bin.get_app(schema, options), Port: options[:port])
 end
-
-driver = Committee::Drivers.driver_from_name(options[:driver])
-schema = driver.parse(::YAML.load(File.read(args[0])))
-
-Rack::Server.start(app: bin.get_app(schema, options), Port: options[:port])

--- a/bin/committee-stub
+++ b/bin/committee-stub
@@ -9,16 +9,14 @@ args = ARGV.dup
 bin = Committee::Bin::CommitteeStub.new
 options, parser = bin.get_options_parser
 
-if $0 == __FILE__
-  parser.parse!(args)
+parser.parse!(args)
 
-  unless args.count == 1 || options[:help] || !options[:driver]
-    puts parser.to_s
-    exit
-  end
-
-  driver = Committee::Drivers.driver_from_name(options[:driver])
-  schema = driver.parse(::YAML.load(File.read(args[0])))
-
-  Rack::Server.start(app: bin.get_app(schema, options), Port: options[:port])
+unless args.count == 1 || options[:help] || !options[:driver]
+  puts parser.to_s
+  exit
 end
+
+driver = Committee::Drivers.driver_from_name(options[:driver])
+schema = driver.parse(::YAML.load(File.read(args[0])))
+
+Rack::Server.start(app: bin.get_app(schema, options), Port: options[:port])

--- a/bin/committee-stub
+++ b/bin/committee-stub
@@ -11,7 +11,7 @@ options, parser = bin.get_options_parser
 
 parser.parse!(args)
 
-unless args.count == 1 || options[:help] || !options[:driver]
+if options[:help] || !options[:driver]
   puts parser.to_s
   exit
 end

--- a/test/bin_test.rb
+++ b/test/bin_test.rb
@@ -12,6 +12,7 @@ require_relative "test_helper"
 describe "executables in bin/" do
   before do
     @bin_dir = File.expand_path("../../bin", __FILE__)
+    ARGV[0] = '-h'
   end
 
   it "has roughly valid Ruby structure for committee-stub" do


### PR DESCRIPTION
Is executable file path check necessary?

Because of this check, below command does nothing.

```
$ gem install committee
$ committee-stub -h
# nothing to happen
```

MyEnvironment:

```
~ $ rbenv -v                                                                                                                                                                                               00:44:37
rbenv 1.1.1-gc8ba27f
~ $ ruby -v                                                                                                                                                                                                00:44:53
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin15]
```

After inserting debug print in `bin/committee-stub` and executing it, the resuls is as follows

```
p $0
=>"MY_HOME/.rbenv/versions/2.4.1/bin/committee-stub"
p __FILE__
=>"MY_HOME/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/committee-2.1.0/bin/committee-stub"
```
