### PR TITLE
Suppress duprecation warning in test

### DIFF
--- a/test/string_params_coercer_test.rb
+++ b/test/string_params_coercer_test.rb
@@ -121,7 +121,12 @@ describe Committee::StringParamsCoercer do
   def check_convert(key, before_value, after_value)
     data = {key => before_value}
     call(data)
-    assert_equal(data[key], after_value)
+
+    if !after_value.nil?
+      assert_equal(data[key], after_value)
+    else
+      assert_nil(data[key])
+    end
   end
 
   def call(data, options={})


### PR DESCRIPTION
## Summary

```
DEPRECATED: Use assert_nil if expecting nil from /path/to/committee/test/string_params_coercer_test.rb:124. This will fail in Minitest 6.
```

* I've fixed this warning.
* In case what we checks `nil == nil`, it seems that we have to use `assert_nil` instead of `assert_equal`.