### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.executables   << "committee-stub"
   s.files         = Dir["{bin,lib,test}/**/*.rb"]
 
+  s.required_ruby_version = ">= 2.0.0"
+
   s.add_dependency "json_schema", "~> 0.14", ">= 0.14.3"
 
   # Rack 2.0+ requires Ruby >= 2.2.2 which is problematic for the test suite on


### PR DESCRIPTION
## Summary

* This gem supports ruby version 2.0.0 or higher.
* It seems it's better to describe required ruby version in its gemspec.