### PR TITLE
Update example dependencies

### DIFF
--- a/examples/Gemfile.lock
+++ b/examples/Gemfile.lock
@@ -1,22 +1,22 @@
 PATH
   remote: ..
   specs:
-    committee (2.0.1)
+    committee (2.1.1)
       json_schema (~> 0.14, >= 0.14.3)
       rack (>= 1.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    json_schema (0.17.2)
+    json_schema (0.19.1)
     mustermann (1.0.2)
-    rack (2.0.4)
-    rack-protection (2.0.1)
+    rack (2.0.5)
+    rack-protection (2.0.3)
       rack
-    sinatra (2.0.1)
+    sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.3)
       tilt (~> 2.0)
     tilt (2.0.8)
 
@@ -26,3 +26,6 @@ PLATFORMS
 DEPENDENCIES
   committee!
   sinatra
+
+BUNDLED WITH
+   1.15.4


### PR DESCRIPTION
GitHub recommends moving off of Sinatra 2.0.1 because it has known
security vulnerabilities. Here we do a periodic update of all
dependencies.