### PR TITLE
Allow multipart/form-data in Committee::RequestUnpacker

### DIFF
--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -25,7 +25,7 @@ module Committee
 
       params = if params
         params
-      elsif @allow_form_params && @request.media_type == "application/x-www-form-urlencoded"
+      elsif @allow_form_params && %w[application/x-www-form-urlencoded multipart/form-data].include?(@request.media_type)
         # Actually, POST means anything in the request body, could be from
         # PUT or PATCH too. Silly Rack.
         p = @request.POST

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -23,33 +23,39 @@ describe Committee::RequestUnpacker do
   end
 
   it "doesn't unpack JSON under other Content-Types" do
-    env = {
-      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-      "rack.input"   => StringIO.new('{"x":"y"}'),
-    }
-    request = Rack::Request.new(env)
-    params, _ = Committee::RequestUnpacker.new(request).call
-    assert_equal({}, params)
+    %w[application/x-www-form-urlencoded multipart/form-data].each do |content_type|
+      env = {
+        "CONTENT_TYPE" => content_type,
+        "rack.input"   => StringIO.new('{"x":"y"}'),
+      }
+      request = Rack::Request.new(env)
+      params, _ = Committee::RequestUnpacker.new(request).call
+      assert_equal({}, params)
+    end
   end
 
   it "unpacks JSON under other Content-Types with optimistic_json" do
-    env = {
-      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-      "rack.input"   => StringIO.new('{"x":"y"}'),
-    }
-    request = Rack::Request.new(env)
-    params, _ = Committee::RequestUnpacker.new(request, optimistic_json: true).call
-    assert_equal({ "x" => "y" }, params)
+    %w[application/x-www-form-urlencoded multipart/form-data].each do |content_type|
+      env = {
+        "CONTENT_TYPE" => content_type,
+        "rack.input"   => StringIO.new('{"x":"y"}'),
+      }
+      request = Rack::Request.new(env)
+      params, _ = Committee::RequestUnpacker.new(request, optimistic_json: true).call
+      assert_equal({ "x" => "y" }, params)
+    end
   end
 
   it "returns {} when unpacking non-JSON with optimistic_json" do
-    env = {
-      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-      "rack.input"   => StringIO.new('x=y&foo=42'),
-    }
-    request = Rack::Request.new(env)
-    params, _ = Committee::RequestUnpacker.new(request, optimistic_json: true).call
-    assert_equal({}, params)
+    %w[application/x-www-form-urlencoded multipart/form-data].each do |content_type|
+      env = {
+        "CONTENT_TYPE" => content_type,
+        "rack.input"   => StringIO.new('x=y&foo=42'),
+      }
+      request = Rack::Request.new(env)
+      params, _ = Committee::RequestUnpacker.new(request, optimistic_json: true).call
+      assert_equal({}, params)
+    end
   end
 
   it "unpacks an empty hash on an empty request body" do
@@ -63,53 +69,61 @@ describe Committee::RequestUnpacker do
   end
 
   it "doesn't unpack form params" do
-    env = {
-      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-      "rack.input"   => StringIO.new("x=y"),
-    }
-    request = Rack::Request.new(env)
-    params, _ = Committee::RequestUnpacker.new(request).call
-    assert_equal({}, params)
+    %w[application/x-www-form-urlencoded multipart/form-data].each do |content_type|
+      env = {
+        "CONTENT_TYPE" => content_type,
+        "rack.input"   => StringIO.new("x=y"),
+      }
+      request = Rack::Request.new(env)
+      params, _ = Committee::RequestUnpacker.new(request).call
+      assert_equal({}, params)
+    end
   end
 
   it "unpacks form params with allow_form_params" do
-    env = {
-      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-      "rack.input"   => StringIO.new("x=y"),
-    }
-    request = Rack::Request.new(env)
-    params, _ = Committee::RequestUnpacker.new(request, allow_form_params: true).call
-    assert_equal({ "x" => "y" }, params)
+    %w[application/x-www-form-urlencoded multipart/form-data].each do |content_type|
+      env = {
+        "CONTENT_TYPE" => content_type,
+        "rack.input"   => StringIO.new("x=y"),
+      }
+      request = Rack::Request.new(env)
+      params, _ = Committee::RequestUnpacker.new(request, allow_form_params: true).call
+      assert_equal({ "x" => "y" }, params)
+    end
   end
 
   it "coerces form params with coerce_form_params and a schema" do
-    schema = JsonSchema::Schema.new
-    schema.properties = { "x" => JsonSchema::Schema.new }
-    schema.properties["x"].type = ["integer"]
+    %w[application/x-www-form-urlencoded multipart/form-data].each do |content_type|
+      schema = JsonSchema::Schema.new
+      schema.properties = { "x" => JsonSchema::Schema.new }
+      schema.properties["x"].type = ["integer"]
 
-    env = {
-      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-      "rack.input"   => StringIO.new("x=1"),
-    }
-    request = Rack::Request.new(env)
-    params, _ = Committee::RequestUnpacker.new(
-      request,
-      allow_form_params: true,
-      coerce_form_params: true,
-      schema: schema
-    ).call
-    assert_equal({ "x" => 1 }, params)
+      env = {
+        "CONTENT_TYPE" => content_type,
+        "rack.input"   => StringIO.new("x=1"),
+      }
+      request = Rack::Request.new(env)
+      params, _ = Committee::RequestUnpacker.new(
+        request,
+        allow_form_params: true,
+        coerce_form_params: true,
+        schema: schema
+      ).call
+      assert_equal({ "x" => 1 }, params)
+    end
   end
 
   it "unpacks form & query params with allow_form_params and allow_query_params" do
-    env = {
-      "CONTENT_TYPE" => "application/x-www-form-urlencoded",
-      "rack.input"   => StringIO.new("x=y"),
-      "QUERY_STRING" => "a=b"
-    }
-    request = Rack::Request.new(env)
-    params, _ = Committee::RequestUnpacker.new(request, allow_form_params: true, allow_query_params: true).call
-    assert_equal({ "x" => "y", "a" => "b" }, params)
+    %w[application/x-www-form-urlencoded multipart/form-data].each do |content_type|
+      env = {
+        "CONTENT_TYPE" => content_type,
+        "rack.input"   => StringIO.new("x=y"),
+        "QUERY_STRING" => "a=b"
+      }
+      request = Rack::Request.new(env)
+      params, _ = Committee::RequestUnpacker.new(request, allow_form_params: true, allow_query_params: true).call
+      assert_equal({ "x" => "y", "a" => "b" }, params)
+    end
   end
 
   it "unpacks query params with allow_query_params" do


### PR DESCRIPTION
## Summary

* When allow_form_params is true and request.media_type is multipart/form-data, Committee::RequestUnpacker\#call is expected to return formatted params, but actually returns empty hash. This behavier seems a bug, so I've fixed it.