### PR TITLE
Add numeric response status support for openapi 2

### DIFF
--- a/lib/committee/drivers/open_api_2.rb
+++ b/lib/committee/drivers/open_api_2.rb
@@ -229,7 +229,7 @@ module Committee::Drivers
         # Sort responses so that we can try to prefer any 3-digit status code.
         # If there are none, we'll just take anything from the list.
         ordered_responses = link_data["responses"].
-          select { |k, v| k =~ /[0-9]{3}/ }
+          select { |k, v| k.to_s =~ /[0-9]{3}/ }
         if first = ordered_responses.first
           [first[0].to_i, first[1]]
         else

--- a/test/drivers/open_api_2_test.rb
+++ b/test/drivers/open_api_2_test.rb
@@ -84,6 +84,18 @@ describe Committee::Drivers::OpenAPI2 do
     assert_equal({ 'description' => '302 response' }, link.target_schema.data)
   end
 
+  it "prefers any numeric three-digit response next" do
+    schema_data = schema_data_with_responses({
+      'default' => { 'schema' => { 'description' => 'default response' } },
+      302 => { 'schema' => { 'description' => '302 response' } },
+    })
+
+    schema = @driver.parse(schema_data)
+    link = schema.routes['GET'][0][1]
+    assert_equal 302, link.status_success
+    assert_equal({ 'description' => '302 response' }, link.target_schema.data)
+  end
+
   it "falls back to no response" do
     schema_data = schema_data_with_responses({})
 


### PR DESCRIPTION
I can't use numeric response status code other than 200 and 201 in Open API 2 schema.
This PR will add support for it.

References: #125

## OK
```yaml
responses:
  '202':
    description: accepted
    schema:
      $ref: "#/definitions/Pet"
```

## NG
```yaml
responses:
  202:
    description: accepted
    schema:
      $ref: "#/definitions/Pet"
```