### PR TITLE
Refactoring RequestValidation and ResponseValidation

### DIFF
--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -21,6 +21,9 @@ require_relative "committee/middleware/request_validation"
 require_relative "committee/middleware/response_validation"
 require_relative "committee/middleware/stub"
 
+require_relative "committee/schema_validator/hyper_schema"
+require_relative "committee/schema_validator/option"
+
 require_relative "committee/bin/committee_stub"
 
 require_relative "committee/test/methods"

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -7,7 +7,6 @@ require_relative "committee/string_params_coercer"
 require_relative "committee/parameter_coercer"
 require_relative "committee/request_unpacker"
 require_relative "committee/response_generator"
-require_relative "committee/response_validator"
 require_relative "committee/router"
 require_relative "committee/validation_error"
 
@@ -23,6 +22,7 @@ require_relative "committee/middleware/stub"
 require_relative "committee/schema_validator/option"
 require_relative "committee/schema_validator/hyper_schema"
 require_relative "committee/schema_validator/hyper_schema/request_validator"
+require_relative "committee/schema_validator/hyper_schema/response_validator"
 
 require_relative "committee/bin/committee_stub"
 

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -6,7 +6,6 @@ require_relative "committee/errors"
 require_relative "committee/string_params_coercer"
 require_relative "committee/parameter_coercer"
 require_relative "committee/request_unpacker"
-require_relative "committee/request_validator"
 require_relative "committee/response_generator"
 require_relative "committee/response_validator"
 require_relative "committee/router"
@@ -21,8 +20,9 @@ require_relative "committee/middleware/request_validation"
 require_relative "committee/middleware/response_validation"
 require_relative "committee/middleware/stub"
 
-require_relative "committee/schema_validator/hyper_schema"
 require_relative "committee/schema_validator/option"
+require_relative "committee/schema_validator/hyper_schema"
+require_relative "committee/schema_validator/hyper_schema/request_validator"
 
 require_relative "committee/bin/committee_stub"
 

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -7,7 +7,7 @@ require_relative "committee/string_params_coercer"
 require_relative "committee/parameter_coercer"
 require_relative "committee/request_unpacker"
 require_relative "committee/response_generator"
-require_relative "committee/router"
+
 require_relative "committee/validation_error"
 
 require_relative "committee/drivers"
@@ -23,6 +23,7 @@ require_relative "committee/schema_validator/option"
 require_relative "committee/schema_validator/hyper_schema"
 require_relative "committee/schema_validator/hyper_schema/request_validator"
 require_relative "committee/schema_validator/hyper_schema/response_validator"
+require_relative "committee/schema_validator/hyper_schema/router"
 
 require_relative "committee/bin/committee_stub"
 

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -58,8 +58,9 @@ module Committee
         raise "needs implementation"
       end
 
-      def build_router(validator_option:, prefix:)
-        Committee::SchemaValidator::HyperSchema::Router.new(self, validator_option: validator_option, prefix: prefix)
+      def build_router(options)
+        validator_option = Committee::SchemaValidator::Option.new(options, self)
+        Committee::SchemaValidator::HyperSchema::Router.new(self, validator_option)
       end
     end
   end

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -57,6 +57,10 @@ module Committee
       def driver
         raise "needs implementation"
       end
+
+      def build_router(validator_option:, prefix:)
+        Committee::SchemaValidator::HyperSchema::Router.new(self, validator_option: validator_option, prefix: prefix)
+      end
     end
   end
 end

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -4,14 +4,11 @@ module Committee::Middleware
       @app = app
 
       @error_class = options.fetch(:error_class, Committee::ValidationError)
-      @params_key = options[:params_key] || "committee.params"
-      @headers_key = options[:headers_key] || "committee.headers"
+
       @raise = options[:raise]
       @schema = get_schema(options)
 
-      @validator_option = Committee::SchemaValidator::Option.new(@params_key, @headers_key, options, @schema)
-
-      @router = @schema.build_router(validator_option: @validator_option, prefix: options[:prefix])
+      @router = @schema.build_router(options)
     end
 
     def call(env)

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -13,6 +13,8 @@ module Committee::Middleware
       @router = Committee::Router.new(@schema,
         prefix: options[:prefix]
       )
+
+      @validator_option = Committee::SchemaValidator::Option.new(@params_key, @headers_key, options, @schema)
     end
 
     def call(env)
@@ -75,6 +77,10 @@ module Committee::Middleware
     def warn_string_deprecated
       Committee.warn_deprecated("Committee: passing a string to schema " \
         "option is deprecated; please send a driver object instead.")
+    end
+
+    def build_schema_validator(request)
+      Committee::SchemaValidator::HyperSchema.new(@router, request, @validator_option)
     end
   end
 end

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -7,8 +7,7 @@ module Committee::Middleware
       @params_key = options[:params_key] || "committee.params"
       @headers_key = options[:headers_key] || "committee.headers"
       @raise = options[:raise]
-      @schema = get_schema(options[:schema] ||
-        raise(ArgumentError, "Committee: need option `schema`"))
+      @schema = get_schema(options)
 
       @validator_option = Committee::SchemaValidator::Option.new(@params_key, @headers_key, options, @schema)
 
@@ -27,54 +26,21 @@ module Committee::Middleware
 
     private
 
-    # For modern use of the library a schema should be an instance of
-    # Committee::Drivers::Schema so that we know that all the computationally
-    # difficult parsing is already done by the time we try to handle any
-    # request.
-    #
-    # However, for reasons of backwards compatibility we also allow schema
-    # input to be a string, a data hash, or a JsonSchema::Schema. In the former
-    # two cases we just parse as if we were sent hyper-schema. In the latter,
-    # we have the hyper-schema driver wrap it in a new Committee object.
-    def get_schema(schema)
-      # These are in a separately conditional ladder so that we only show the
-      # user one warning.
-      if schema.is_a?(String)
-        warn_string_deprecated
-      elsif schema.is_a?(Hash)
-        warn_hash_deprecated
+    def get_schema(options)
+      schema = options[:schema]
+
+      if schema
+
+        # Expect the type we want by now. If we don't have it, the user passed
+        # something else non-standard in.
+        if !schema.is_a?(Committee::Drivers::Schema)
+          raise ArgumentError, "Committee: schema expected to be an instance of Committee::Drivers::Schema."
+        end
+
+        return schema
       end
 
-      if schema.is_a?(String)
-        schema = JSON.parse(schema)
-      end
-
-      if schema.is_a?(Hash) || schema.is_a?(JsonSchema::Schema)
-        driver = Committee::Drivers::HyperSchema.new
-
-        # The driver itself has its own special cases to be able to parse
-        # either a hash or JsonSchema::Schema object.
-        schema = driver.parse(schema)
-      end
-
-      # Expect the type we want by now. If we don't have it, the user passed
-      # something else non-standard in.
-      if !schema.is_a?(Committee::Drivers::Schema)
-        raise ArgumentError, "Committee: schema expected to be a hash or " \
-          "an instance of Committee::Drivers::Schema."
-      end
-
-      schema
-    end
-
-    def warn_hash_deprecated
-      Committee.warn_deprecated("Committee: passing a hash to schema " \
-        "option is deprecated; please send a driver object instead.")
-    end
-
-    def warn_string_deprecated
-      Committee.warn_deprecated("Committee: passing a string to schema " \
-        "option is deprecated; please send a driver object instead.")
+      raise(ArgumentError, "Committee: need option `schema`")
     end
 
     def build_schema_validator(request)

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -10,11 +10,9 @@ module Committee::Middleware
       @schema = get_schema(options[:schema] ||
         raise(ArgumentError, "Committee: need option `schema`"))
 
-      @router = Committee::Router.new(@schema,
-        prefix: options[:prefix]
-      )
-
       @validator_option = Committee::SchemaValidator::Option.new(@params_key, @headers_key, options, @schema)
+
+      @router = @schema.build_router(validator_option: @validator_option, prefix: options[:prefix])
     end
 
     def call(env)
@@ -80,7 +78,7 @@ module Committee::Middleware
     end
 
     def build_schema_validator(request)
-      Committee::SchemaValidator::HyperSchema.new(@router, request, @validator_option)
+      @router.build_schema_validator(request)
     end
   end
 end

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -7,8 +7,6 @@ module Committee::Middleware
 
       # deprecated
       @allow_extra = options[:allow_extra]
-
-      @validator_option = Committee::SchemaValidator::Option.new(@params_key, @headers_key, options, @schema)
     end
 
     def handle(request)
@@ -32,11 +30,5 @@ module Committee::Middleware
       raise Committee::InvalidRequest if @raise
       @error_class.new(400, :bad_request, "Request body wasn't valid JSON.").render
     end
-
-    private
-    
-      def build_schema_validator(request)
-        Committee::SchemaValidator::HyperSchema.new(@router, request, @validator_option)
-      end
   end
 end

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -13,7 +13,7 @@ module Committee::Middleware
 
     def handle(request)
       schema_validator = build_schema_validator(request)
-      schema_validator.call(request)
+      schema_validator.request_validate(request)
 
       raise Committee::NotFound, "That request method and path combination isn't defined." if !schema_validator.link_exist? && @strict
 

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -3,67 +3,21 @@ module Committee::Middleware
     def initialize(app, options={})
       super
 
-      @allow_form_params   = options.fetch(:allow_form_params, true)
-      @allow_query_params  = options.fetch(:allow_query_params, true)
-      @check_content_type  = options.fetch(:check_content_type, true)
-      @check_header        = options.fetch(:check_header, true)
-      @optimistic_json     = options.fetch(:optimistic_json, false)
-      @strict              = options[:strict]
-      @coerce_date_times   = options.fetch(:coerce_date_times, false)
-      @coerce_recursive = options.fetch(:coerce_recursive, true)
-
-      @coerce_form_params = options.fetch(:coerce_form_params,
-        @schema.driver.default_coerce_form_params)
-      @coerce_path_params = options.fetch(:coerce_path_params,
-        @schema.driver.default_path_params)
-      @coerce_query_params = options.fetch(:coerce_query_params,
-        @schema.driver.default_query_params)
+      @strict  = options[:strict]
 
       # deprecated
       @allow_extra = options[:allow_extra]
+
+      @validator_option = Committee::SchemaValidator::Option.new(@params_key, @headers_key, options, @schema)
     end
 
     def handle(request)
-      link, param_matches = @router.find_request_link(request)
+      schema_validator = build_schema_validator(request)
+      schema_validator.call(request)
 
-      if link
-        # Attempts to coerce parameters that appear in a link's URL to Ruby
-        # types that can be validated with a schema.
-        if @coerce_path_params
-          Committee::StringParamsCoercer.new(param_matches, link.schema, coerce_recursive: @coerce_recursive).call!
-        end
+      raise Committee::NotFound, "That request method and path combination isn't defined." if !schema_validator.link_exist? && @strict
 
-        # Attempts to coerce parameters that appear in a query string to Ruby
-        # types that can be validated with a schema.
-        if @coerce_query_params && !request.GET.nil? && !link.schema.nil?
-          Committee::StringParamsCoercer.new(request.GET, link.schema, coerce_recursive: @coerce_recursive).call!
-        end
-      end
-
-      request.env[@params_key], request.env[@headers_key] = Committee::RequestUnpacker.new(
-        request,
-        allow_form_params:  @allow_form_params,
-        allow_query_params: @allow_query_params,
-        coerce_form_params: @coerce_form_params,
-        optimistic_json:    @optimistic_json,
-        schema:             link ? link.schema : nil
-      ).call
-
-      request.env[@params_key].merge!(param_matches) if param_matches
-
-      if link
-        validator = Committee::RequestValidator.new(link, check_content_type: @check_content_type, check_header: @check_header)
-        validator.call(request, request.env[@params_key], request.env[@headers_key])
-
-        parameter_coerce!(request, link, @params_key)
-        parameter_coerce!(request, link, "rack.request.query_hash") if !request.GET.nil? && !link.schema.nil?
-
-        @app.call(request.env)
-      elsif @strict
-        raise Committee::NotFound, "That request method and path combination isn't defined."
-      else
-        @app.call(request.env)
-      end
+      @app.call(request.env)
     rescue Committee::BadRequest, Committee::InvalidRequest
       raise if @raise
       @error_class.new(400, :bad_request, $!.message).render
@@ -80,11 +34,9 @@ module Committee::Middleware
     end
 
     private
-
-      def parameter_coerce!(request, link, coerce_key)
-        Committee::ParameterCoercer.
-            new(request.env[coerce_key], link.schema, coerce_date_times: @coerce_date_times, coerce_recursive: @coerce_recursive).
-            call!
+    
+      def build_schema_validator(request)
+        Committee::SchemaValidator::HyperSchema.new(@router, request, @validator_option)
       end
   end
 end

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -25,50 +25,52 @@ class Committee::SchemaValidator
       parameter_coerce!(request, link, "rack.request.query_hash") if link_exist? && !request.GET.nil? && !link.schema.nil?
     end
 
-    def coerce_path_params
-      return unless link_exist?
-
-      Committee::StringParamsCoercer.new(param_matches, link.schema, coerce_recursive: validator_option.coerce_recursive).call!
-      param_matches
-    end
-
-    def coerce_query_params(request)
-      return unless link_exist?
-      return if request.GET.nil? || link.schema.nil?
-
-      Committee::StringParamsCoercer.new(request.GET, link.schema, coerce_recursive: validator_option.coerce_recursive).call!
-    end
-
-    def request_unpack(request)
-      request.env[validator_option.params_key], request.env[validator_option.headers_key] = Committee::RequestUnpacker.new(
-          request,
-          allow_form_params:  validator_option.allow_form_params,
-          allow_query_params: validator_option.allow_query_params,
-          coerce_form_params: validator_option.coerce_form_params,
-          optimistic_json:    validator_option.optimistic_json,
-          schema:             link ? link.schema : nil
-      ).call
-    end
-
-    def request_schema_validation(request)
-      return unless link_exist?
-      validator = Committee::SchemaValidator::HyperSchema::RequestValidator.new(link, check_content_type: validator_option.check_content_type, check_header: validator_option.check_header)
-      validator.call(request, request.env[validator_option.params_key], request.env[validator_option.headers_key])
-    end
-
-    def parameter_coerce!(request, link, coerce_key)
-      return unless link_exist?
-
-      Committee::ParameterCoercer.
-          new(request.env[coerce_key],
-              link.schema,
-              coerce_date_times: validator_option.coerce_date_times,
-              coerce_recursive: validator_option.coerce_recursive).
-          call!
-    end
-
     def link_exist?
       !link.nil?
     end
+
+    private
+
+      def coerce_path_params
+        return unless link_exist?
+
+        Committee::StringParamsCoercer.new(param_matches, link.schema, coerce_recursive: validator_option.coerce_recursive).call!
+        param_matches
+      end
+
+      def coerce_query_params(request)
+        return unless link_exist?
+        return if request.GET.nil? || link.schema.nil?
+
+        Committee::StringParamsCoercer.new(request.GET, link.schema, coerce_recursive: validator_option.coerce_recursive).call!
+      end
+
+      def request_unpack(request)
+        request.env[validator_option.params_key], request.env[validator_option.headers_key] = Committee::RequestUnpacker.new(
+            request,
+            allow_form_params:  validator_option.allow_form_params,
+            allow_query_params: validator_option.allow_query_params,
+            coerce_form_params: validator_option.coerce_form_params,
+            optimistic_json:    validator_option.optimistic_json,
+            schema:             link ? link.schema : nil
+        ).call
+      end
+
+      def request_schema_validation(request)
+        return unless link_exist?
+        validator = Committee::SchemaValidator::HyperSchema::RequestValidator.new(link, check_content_type: validator_option.check_content_type, check_header: validator_option.check_header)
+        validator.call(request, request.env[validator_option.params_key], request.env[validator_option.headers_key])
+      end
+
+      def parameter_coerce!(request, link, coerce_key)
+        return unless link_exist?
+
+        Committee::ParameterCoercer.
+            new(request.env[coerce_key],
+                link.schema,
+                coerce_date_times: validator_option.coerce_date_times,
+                coerce_recursive: validator_option.coerce_recursive).
+            call!
+      end
   end
 end

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -1,0 +1,75 @@
+class Committee::SchemaValidator
+  class HyperSchema
+    attr_reader :link, :param_matches, :validator_option
+
+    def initialize(router, request, validator_option)
+      @link, @param_matches = router.find_request_link(request)
+      @validator_option = validator_option
+    end
+
+    def call(request)
+
+      # Attempts to coerce parameters that appear in a link's URL to Ruby
+      # types that can be validated with a schema.
+      param_matches_hash = coerce_path_params ? coerce_path_params : {}
+
+      # Attempts to coerce parameters that appear in a query string to Ruby
+      # types that can be validated with a schema.
+      coerce_query_params(request) if validator_option.coerce_query_params
+
+      request_unpack(request)
+
+      request.env[validator_option.params_key].merge!(param_matches_hash) if param_matches_hash
+
+      request_validate(request)
+      parameter_coerce!(request, link, validator_option.params_key)
+      parameter_coerce!(request, link, "rack.request.query_hash") if link_exist? && !request.GET.nil? && !link.schema.nil?
+    end
+
+    def coerce_path_params
+      return unless link_exist?
+
+      Committee::StringParamsCoercer.new(param_matches, link.schema, coerce_recursive: validator_option.coerce_recursive).call!
+      param_matches
+    end
+
+    def coerce_query_params(request)
+      return unless link_exist?
+      return if request.GET.nil? || link.schema.nil?
+
+      Committee::StringParamsCoercer.new(request.GET, link.schema, coerce_recursive: validator_option.coerce_recursive).call!
+    end
+
+    def request_unpack(request)
+      request.env[validator_option.params_key], request.env[validator_option.headers_key] = Committee::RequestUnpacker.new(
+          request,
+          allow_form_params:  validator_option.allow_form_params,
+          allow_query_params: validator_option.allow_query_params,
+          coerce_form_params: validator_option.coerce_form_params,
+          optimistic_json:    validator_option.optimistic_json,
+          schema:             link ? link.schema : nil
+      ).call
+    end
+
+    def request_validate(request)
+      return unless link_exist?
+      validator = Committee::RequestValidator.new(link, check_content_type: validator_option.check_content_type, check_header: validator_option.check_header)
+      validator.call(request, request.env[validator_option.params_key], request.env[validator_option.headers_key])
+    end
+
+    def parameter_coerce!(request, link, coerce_key)
+      return unless link_exist?
+
+      Committee::ParameterCoercer.
+          new(request.env[coerce_key],
+              link.schema,
+              coerce_date_times: validator_option.coerce_date_times,
+              coerce_recursive: validator_option.coerce_recursive).
+          call!
+    end
+
+    def link_exist?
+      !link.nil?
+    end
+  end
+end

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -10,7 +10,7 @@ class Committee::SchemaValidator
     def request_validate(request)
       # Attempts to coerce parameters that appear in a link's URL to Ruby
       # types that can be validated with a schema.
-      param_matches_hash = coerce_path_params ? coerce_path_params : {}
+      param_matches_hash = validator_option.coerce_path_params ? coerce_path_params : {}
 
       # Attempts to coerce parameters that appear in a query string to Ruby
       # types that can be validated with a schema.

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -33,7 +33,7 @@ class Committee::SchemaValidator
         full_body << chunk
       end
       data = JSON.parse(full_body)
-      Committee::ResponseValidator.new(link, validate_errors: validator_option.validate_errors).call(status, headers, data)
+      Committee::SchemaValidator::HyperSchema::ResponseValidator.new(link, validate_errors: validator_option.validate_errors).call(status, headers, data)
     end
 
     def link_exist?

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -25,6 +25,17 @@ class Committee::SchemaValidator
       parameter_coerce!(request, link, "rack.request.query_hash") if link_exist? && !request.GET.nil? && !link.schema.nil?
     end
 
+    def response_validate(status, headers, response)
+      return unless link_exist?
+
+      full_body = ""
+      response.each do |chunk|
+        full_body << chunk
+      end
+      data = JSON.parse(full_body)
+      Committee::ResponseValidator.new(link, validate_errors: validator_option.validate_errors).call(status, headers, data)
+    end
+
     def link_exist?
       !link.nil?
     end

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -7,8 +7,7 @@ class Committee::SchemaValidator
       @validator_option = validator_option
     end
 
-    def call(request)
-
+    def request_validate(request)
       # Attempts to coerce parameters that appear in a link's URL to Ruby
       # types that can be validated with a schema.
       param_matches_hash = coerce_path_params ? coerce_path_params : {}
@@ -21,7 +20,7 @@ class Committee::SchemaValidator
 
       request.env[validator_option.params_key].merge!(param_matches_hash) if param_matches_hash
 
-      request_validate(request)
+      request_schema_validation(request)
       parameter_coerce!(request, link, validator_option.params_key)
       parameter_coerce!(request, link, "rack.request.query_hash") if link_exist? && !request.GET.nil? && !link.schema.nil?
     end
@@ -51,9 +50,9 @@ class Committee::SchemaValidator
       ).call
     end
 
-    def request_validate(request)
+    def request_schema_validation(request)
       return unless link_exist?
-      validator = Committee::RequestValidator.new(link, check_content_type: validator_option.check_content_type, check_header: validator_option.check_header)
+      validator = Committee::SchemaValidator::HyperSchema::RequestValidator.new(link, check_content_type: validator_option.check_content_type, check_header: validator_option.check_header)
       validator.call(request, request.env[validator_option.params_key], request.env[validator_option.headers_key])
     end
 

--- a/lib/committee/schema_validator/hyper_schema/request_validator.rb
+++ b/lib/committee/schema_validator/hyper_schema/request_validator.rb
@@ -1,5 +1,5 @@
 module Committee
-  class RequestValidator
+  class SchemaValidator::HyperSchema::RequestValidator
     def initialize(link, options = {})
       @link = link
       @check_content_type = options.fetch(:check_content_type, true)

--- a/lib/committee/schema_validator/hyper_schema/response_validator.rb
+++ b/lib/committee/schema_validator/hyper_schema/response_validator.rb
@@ -1,5 +1,5 @@
 module Committee
-  class ResponseValidator
+  class SchemaValidator::HyperSchema::ResponseValidator
     attr_reader :validate_errors
 
     def initialize(link, options = {})

--- a/lib/committee/schema_validator/hyper_schema/router.rb
+++ b/lib/committee/schema_validator/hyper_schema/router.rb
@@ -1,9 +1,11 @@
 module Committee
-  class Router
+  class SchemaValidator::HyperSchema::Router
     def initialize(schema, options = {})
       @prefix = options[:prefix]
       @prefix_regexp = /\A#{Regexp.escape(@prefix)}/.freeze if @prefix
       @schema = schema
+
+      @validator_option = options[:validator_option]
     end
 
     def includes?(path)
@@ -29,6 +31,10 @@ module Committee
 
     def find_request_link(request)
       find_link(request.request_method, request.path_info)
+    end
+
+    def build_schema_validator(request)
+      Committee::SchemaValidator::HyperSchema.new(self, request, @validator_option)
     end
   end
 end

--- a/lib/committee/schema_validator/hyper_schema/router.rb
+++ b/lib/committee/schema_validator/hyper_schema/router.rb
@@ -1,11 +1,11 @@
 module Committee
   class SchemaValidator::HyperSchema::Router
-    def initialize(schema, options = {})
-      @prefix = options[:prefix]
+    def initialize(schema, validator_option)
+      @prefix = validator_option.prefix
       @prefix_regexp = /\A#{Regexp.escape(@prefix)}/.freeze if @prefix
       @schema = schema
 
-      @validator_option = options[:validator_option]
+      @validator_option = validator_option
     end
 
     def includes?(path)

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -1,10 +1,11 @@
 class Committee::SchemaValidator
   class Option
-    attr_reader :coerce_recursive, :params_key, :allow_form_params, :allow_query_params, :optimistic_json, :coerce_form_params, :headers_key, :coerce_query_params, :coerce_path_params, :check_content_type, :check_header, :coerce_date_times, :validate_errors
+    attr_reader :coerce_recursive, :params_key, :allow_form_params, :allow_query_params, :optimistic_json, :coerce_form_params, :headers_key, :coerce_query_params, :coerce_path_params, :check_content_type, :check_header, :coerce_date_times, :validate_errors, :prefix
 
-    def initialize(params_key, headers_key, options, schema)
-      @headers_key = headers_key
-      @params_key = params_key
+    def initialize(options, schema)
+      @headers_key = options[:headers_key] || "committee.headers"
+      @params_key = options[:params_key] || "committee.params"
+
       @coerce_recursive = options.fetch(:coerce_recursive, true)
 
       @allow_form_params   = options.fetch(:allow_form_params, true)
@@ -25,6 +26,7 @@ class Committee::SchemaValidator
 
       @coerce_date_times   = options.fetch(:coerce_date_times, false)
 
+      @prefix = options[:prefix]
 
       # response option
       @validate_errors = options[:validate_errors]

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -1,6 +1,6 @@
 class Committee::SchemaValidator
   class Option
-    attr_reader :coerce_recursive, :params_key, :allow_form_params, :allow_query_params, :optimistic_json, :coerce_form_params, :headers_key, :coerce_query_params, :coerce_path_params, :check_content_type, :check_header, :coerce_date_times
+    attr_reader :coerce_recursive, :params_key, :allow_form_params, :allow_query_params, :optimistic_json, :coerce_form_params, :headers_key, :coerce_query_params, :coerce_path_params, :check_content_type, :check_header, :coerce_date_times, :validate_errors
 
     def initialize(params_key, headers_key, options, schema)
       @headers_key = headers_key
@@ -24,6 +24,10 @@ class Committee::SchemaValidator
       @check_header        = options.fetch(:check_header, true)
 
       @coerce_date_times   = options.fetch(:coerce_date_times, false)
+
+
+      # response option
+      @validate_errors = options[:validate_errors]
     end
   end
 end

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -1,0 +1,29 @@
+class Committee::SchemaValidator
+  class Option
+    attr_reader :coerce_recursive, :params_key, :allow_form_params, :allow_query_params, :optimistic_json, :coerce_form_params, :headers_key, :coerce_query_params, :coerce_path_params, :check_content_type, :check_header, :coerce_date_times
+
+    def initialize(params_key, headers_key, options, schema)
+      @headers_key = headers_key
+      @params_key = params_key
+      @coerce_recursive = options.fetch(:coerce_recursive, true)
+
+      @allow_form_params   = options.fetch(:allow_form_params, true)
+      @allow_query_params  = options.fetch(:allow_query_params, true)
+      @optimistic_json     = options.fetch(:optimistic_json, false)
+
+      @coerce_form_params = options.fetch(:coerce_form_params,
+                                          schema.driver.default_coerce_form_params)
+
+      @coerce_query_params = options.fetch(:coerce_query_params,
+                                           schema.driver.default_query_params)
+
+      @coerce_path_params = options.fetch(:coerce_path_params,
+                                          schema.driver.default_path_params)
+
+      @check_content_type  = options.fetch(:check_content_type, true)
+      @check_header        = options.fetch(:check_header, true)
+
+      @coerce_date_times   = options.fetch(:coerce_date_times, false)
+    end
+  end
+end

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -32,8 +32,8 @@ module Committee::Test
         end
       end
 
-      @committee_router ||= Committee::SchemaValidator::HyperSchema::Router.new(@committee_schema,
-        prefix: schema_url_prefix)
+      validator_option = Committee::SchemaValidator::Option.new({prefix: schema_url_prefix}, @committee_schema)
+      @committee_router ||= Committee::SchemaValidator::HyperSchema::Router.new(@committee_schema, validator_option)
 
       link, _ = @committee_router.find_request_link(last_request)
       unless link

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -32,7 +32,7 @@ module Committee::Test
         end
       end
 
-      @committee_router ||= Committee::Router.new(@committee_schema,
+      @committee_router ||= Committee::SchemaValidator::HyperSchema::Router.new(@committee_schema,
         prefix: schema_url_prefix)
 
       link, _ = @committee_router.find_request_link(last_request)

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -43,7 +43,7 @@ module Committee::Test
 
       if validate_response?(last_response.status)
         data = JSON.parse(last_response.body)
-        Committee::ResponseValidator.new(link).call(last_response.status, last_response.headers, data)
+        Committee::SchemaValidator::HyperSchema::ResponseValidator.new(link).call(last_response.status, last_response.headers, data)
       end
     end
 
@@ -85,7 +85,7 @@ module Committee::Test
     end
 
     def validate_response?(status)
-      Committee::ResponseValidator.validate?(status)
+      Committee::SchemaValidator::HyperSchema::ResponseValidator.validate?(status)
     end
   end
 end

--- a/test/response_validator_test.rb
+++ b/test/response_validator_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-describe Committee::ResponseValidator do
+describe Committee::SchemaValidator::HyperSchema::ResponseValidator do
   before do
     @status = 200
     @headers = {
@@ -101,6 +101,6 @@ describe Committee::ResponseValidator do
   def call
     # hyper-schema link should be dropped into driver wrapper before it's used
     link = Committee::Drivers::HyperSchema::Link.new(@link)
-    Committee::ResponseValidator.new(link).call(@status, @headers, @data)
+    Committee::SchemaValidator::HyperSchema::ResponseValidator.new(link).call(@status, @headers, @data)
   end
 end

--- a/test/schema_validator/hyper_schema/request_validator_test.rb
+++ b/test/schema_validator/hyper_schema/request_validator_test.rb
@@ -1,8 +1,8 @@
-require_relative "test_helper"
+require_relative "../../test_helper"
 
 require "stringio"
 
-describe Committee::RequestValidator do
+describe Committee::SchemaValidator::HyperSchema::RequestValidator do
   describe 'HyperSchema' do
     before do
       @schema = JsonSchema.parse!(hyper_schema_data)
@@ -100,7 +100,7 @@ describe Committee::RequestValidator do
     def call(data, headers={}, options={})
       # hyper-schema link should be dropped into driver wrapper before it's used
       link = Committee::Drivers::HyperSchema::Link.new(@link)
-      Committee::RequestValidator.new(link, options).call(@request, data, headers)
+      Committee::SchemaValidator::HyperSchema::RequestValidator.new(link, options).call(@request, data, headers)
     end
   end
 
@@ -143,7 +143,7 @@ describe Committee::RequestValidator do
 
     def call(data, headers={}, options={})
       # hyper-schema link should be dropped into driver wrapper before it's used
-      Committee::RequestValidator.new(@link, options).call(@request, data, headers)
+      Committee::SchemaValidator::HyperSchema::RequestValidator.new(@link, options).call(@request, data, headers)
     end
   end
 end

--- a/test/schema_validator/hyper_schema/response_validator_test.rb
+++ b/test/schema_validator/hyper_schema/response_validator_test.rb
@@ -1,4 +1,4 @@
-require_relative "test_helper"
+require_relative "../../test_helper"
 
 describe Committee::SchemaValidator::HyperSchema::ResponseValidator do
   before do

--- a/test/schema_validator/hyper_schema/router_test.rb
+++ b/test/schema_validator/hyper_schema/router_test.rb
@@ -55,11 +55,15 @@ describe Committee::SchemaValidator::HyperSchema::Router do
 
   def hyper_schema_router(options = {})
     schema = Committee::Drivers::HyperSchema.new.parse(hyper_schema_data)
-    Committee::SchemaValidator::HyperSchema::Router.new(schema, options)
+    validator_option = Committee::SchemaValidator::Option.new(options, schema)
+
+    Committee::SchemaValidator::HyperSchema::Router.new(schema, validator_option)
   end
 
   def open_api_2_router(options = {})
     schema = Committee::Drivers::OpenAPI2.new.parse(open_api_2_data)
-    Committee::SchemaValidator::HyperSchema::Router.new(schema, options)
+    validator_option = Committee::SchemaValidator::Option.new(options, schema)
+
+    Committee::SchemaValidator::HyperSchema::Router.new(schema, validator_option)
   end
 end

--- a/test/schema_validator/hyper_schema/router_test.rb
+++ b/test/schema_validator/hyper_schema/router_test.rb
@@ -1,6 +1,6 @@
-require_relative "test_helper"
+require_relative "../../test_helper"
 
-describe Committee::Router do
+describe Committee::SchemaValidator::HyperSchema::Router do
   it "builds routes without parameters" do
     link, _ = hyper_schema_router.find_link("GET", "/apps")
     refute_nil link
@@ -55,11 +55,11 @@ describe Committee::Router do
 
   def hyper_schema_router(options = {})
     schema = Committee::Drivers::HyperSchema.new.parse(hyper_schema_data)
-    Committee::Router.new(schema, options)
+    Committee::SchemaValidator::HyperSchema::Router.new(schema, options)
   end
 
   def open_api_2_router(options = {})
     schema = Committee::Drivers::OpenAPI2.new.parse(open_api_2_data)
-    Committee::Router.new(schema, options)
+    Committee::SchemaValidator::HyperSchema::Router.new(schema, options)
   end
 end


### PR DESCRIPTION
Now RequestValidation is deppend on JSON Hyper-Schema structure.
I want to add OpenAPI3 feature so I move HyperSchema Validate class and I'll implement OpenAPI3 Validete class for request validation.

For example, we separate out HyperSchema and OpenAPI3 like this.

https://github.com/interagent/committee/pull/151/files#diff-a88c3c9d73a634d3ff867e3039650637R117

https://github.com/interagent/committee/pull/151/files#diff-1e3c8969dc8423e031bd26758fcba749R45