### PR TITLE
Add Hook triggered when response is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Options:
 * `prefix`: Mounts the middleware to respond at a configured prefix.
 * `raise`: Raise an exception on error instead of responding with a generic error body (defaults to `false`).
 * `validate_errors`: Also validate non-2xx responses (defaults to `false`).
+* `error_handler`: A proc which will be called when error occurs. Take an Error instance as first argument.
 
 Given a simple Sinatra app that responds for an endpoint in an incomplete fashion:
 

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -5,6 +5,7 @@ module Committee::Middleware
     def initialize(app, options = {})
       super
       @validate_errors = options[:validate_errors]
+      @error_handler = options[:error_handler]
     end
 
     def handle(request)
@@ -22,9 +23,11 @@ module Committee::Middleware
 
       [status, headers, response]
     rescue Committee::InvalidResponse
+      @error_handler.call($!) if @error_handler
       raise if @raise
       @error_class.new(500, :invalid_response, $!.message).render
     rescue JSON::ParserError
+      @error_handler.call($!) if @error_handler
       raise Committee::InvalidResponse if @raise
       @error_class.new(500, :invalid_response, "Response wasn't valid JSON.").render
     end


### PR DESCRIPTION
## What

When the response is invalid (judged by ResponseValidator), we want to report errors. In this PR, I add a hook point in ResponseValidation Class.

~This PR is work in progress (Although I tested manually on my local PC).~  I added tests and documents.

## Example

```rb
config.middleware.use Committee::Middleware::ResponseValidation, schema: schema,
                        response_error_handler: ->(e) { Raven.capture_exception(e) }
```

## Review Points

- Is there another way to achieve this? (If so, this PR may be needless and should be closed.)
- API
  - Is lambda suitable here?
  - naming of ~`error_hook`~ `response_error_handler`
- Implementation
  - How should we treat if an unexpected error occurred in that lambda