### PR TITLE
Specify newer versions of rack

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   # older Ruby versions. Check Ruby the version here and put a maximum
   # constraint on Rack if necessary.
   if RUBY_VERSION >= '2.2.2'
-    s.add_dependency "rack", ">= 1.5"
+    s.add_dependency "rack", ">= 2.0.6"
   else
-    s.add_dependency "rack", ">= 1.5", "< 2.0"
+    s.add_dependency "rack", ">= 1.6.11", "< 2.0"
   end
 
   s.add_development_dependency "minitest", "~> 5.3"


### PR DESCRIPTION
- Continue to use Rack < 2.0 for Rubies < 2.2.2.
- Fixes CVE-2018-16471

Not sure how we feel about being exact with the versions, but this does ensure that the CVE is patched for Rubies newer than 2.2.2.
