### PR TITLE
Deprecate method.rb methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,11 @@ describe Committee::Middleware::Stub do
     end
   end
 
-  def schema_path
-    "./my-schema.json"
+  def committee_options
+    json = JSON.parse(File.read("./my-schema.json"))
+    json = Committee::Drivers::HyperSchema.new.parse(json)
+    
+    {schema: schema}
   end
 
   describe "GET /" do
@@ -258,6 +261,21 @@ So please wrap Committee::Drivers::Schema like this.
 json = JSON.parse(File.read(...))
 schema = Committee::Drivers::HyperSchema.new.parse(json)
 use Committee::Middleware::RequestValidation, schema: schema
+```
+
+### Change Test Assertions
+In committee 3.0 we'll drop many method in method.rb.  
+So please overwrite committee_options and return schema data and prefix option.  
+This method should return same data in ResponseValidation option.
+
+```ruby
+def committee_options
+  json = JSON.parse(File.read("./my-schema.json"))
+  schema = Committee::Drivers::HyperSchema.new.parse(json)
+
+  {schema: schema, prefix: "/v1"}
+  # {open_api_3: schema, prefix: "/v1"}
+end
 ```
 
 ## Development

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -41,7 +41,7 @@ module Committee::Test
         raise Committee::InvalidResponse.new(response)
       end
 
-      if validate_response?(last_response.status)
+      if validate?(last_response.status)
         data = JSON.parse(last_response.body)
         Committee::ResponseValidator.new(link).call(last_response.status, last_response.headers, data)
       end
@@ -51,9 +51,21 @@ module Committee::Test
       Committee.warn_deprecated("Committee: use of #assert_schema_content_type is deprecated; use #assert_schema_conform instead.")
     end
 
+    # we use this method 3.0 or later
+    def committee_options
+      Committee.warn_deprecated("Committee: committee 3.0 require overwrite committee options so please use this method.")
+
+      {}
+    end
+
     # Can be overridden with a different driver name for other API definition
     # formats.
     def committee_schema
+      schema = committee_options[:schema]
+      return schema if schema
+
+      Committee.warn_deprecated("Committee: we'll remove committee_schema method in committee 3.0;" \
+        "please use committee_options.")
       nil
     end
 
@@ -61,14 +73,26 @@ module Committee::Test
     # easier to access as a string
     # blob
     def schema_contents
+      Committee.warn_deprecated("Committee: we'll remove schema_contents method in committee 3.0;" \
+        "please use committee_options.")
       JSON.parse(File.read(schema_path))
     end
 
     def schema_path
+      Committee.warn_deprecated("Committee: we'll remove schema_path method in committee 3.0;" \
+        "please use committee_options.")
       raise "Please override #committee_schema."
     end
 
     def schema_url_prefix
+      prefix = committee_options[:prefix]
+      return prefix if prefix
+
+      schema = committee_options[:schema]
+      return nil if schema # committee_options set so we don't show warn message
+
+      Committee.warn_deprecated("Committee: we'll remove schema_url_prefix method in committee 3.0;" \
+        "please use committee_options.")
       nil
     end
 
@@ -85,7 +109,15 @@ module Committee::Test
     end
 
     def validate_response?(status)
+      Committee.warn_deprecated("Committee: w'll remove validate_response? method in committee 3.0")
+
       Committee::ResponseValidator.validate?(status)
     end
+
+    private
+
+      def validate?(status)
+        Committee::ResponseValidator.validate?(status)
+      end
   end
 end

--- a/test/test/methods_new_version_test.rb
+++ b/test/test/methods_new_version_test.rb
@@ -1,0 +1,59 @@
+require_relative "../test_helper"
+
+describe Committee::Test::Methods do
+  include Committee::Test::Methods
+  include Rack::Test::Methods
+
+  def app
+    @app
+  end
+
+  def committee_options
+    @committee_options
+  end
+
+  before do
+    # This is a little icky, but the test methods will cache router and schema
+    # values between tests. This makes sense in real life, but is harmful for
+    # our purposes here in testing the module.
+    @committee_router = nil
+    @committee_schema = nil
+
+    @committee_options = {schema: hyper_schema}
+  end
+
+  describe "#assert_schema_conform" do
+    it "passes through a valid response" do
+      @app = new_rack_app(JSON.generate([ValidApp]))
+      get "/apps"
+      assert_schema_conform
+    end
+
+    it "passes with prefix" do
+      @committee_options.merge!(prefix: "/v1")
+
+      @app = new_rack_app(JSON.generate([ValidApp]))
+      get "/v1/apps"
+      assert_schema_conform
+    end
+
+    it "detects an invalid response Content-Type" do
+      @app = new_rack_app(JSON.generate([ValidApp]), {})
+      get "/apps"
+      e = assert_raises(Committee::InvalidResponse) do
+        assert_schema_conform
+      end
+      assert_match(/response header must be set to/i, e.message)
+    end
+  end
+
+  private
+
+  def new_rack_app(response, headers={ "Content-Type" => "application/json" })
+    Rack::Builder.new {
+      run lambda { |_|
+        [200, headers, [response]]
+      }
+    }
+  end
+end

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -29,12 +29,16 @@ describe Committee::Test::Methods do
 
   describe "#assert_schema_conform" do
     it "passes through a valid response" do
+      mock(Committee).warn_deprecated.with_any_args.times(3)
+
       @app = new_rack_app(JSON.generate([ValidApp]))
       get "/apps"
       assert_schema_conform
     end
 
     it "detects an invalid response Content-Type" do
+      mock(Committee).warn_deprecated.with_any_args.times(3)
+
       @app = new_rack_app(JSON.generate([ValidApp]), {})
       get "/apps"
       e = assert_raises(Committee::InvalidResponse) do
@@ -44,7 +48,7 @@ describe Committee::Test::Methods do
     end
 
     it "accepts schema string (legacy behavior)" do
-      mock(Committee).warn_deprecated.with_any_args
+      mock(Committee).warn_deprecated.with_any_args.times(4)
 
       stub(self).committee_schema { nil }
       stub(self).schema_contents { JSON.dump(hyper_schema_data) }
@@ -55,7 +59,7 @@ describe Committee::Test::Methods do
     end
 
     it "accepts schema hash (legacy behavior)" do
-      mock(Committee).warn_deprecated.with_any_args
+      mock(Committee).warn_deprecated.with_any_args.times(4)
 
       stub(self).committee_schema { nil }
       stub(self).schema_contents { hyper_schema_data }
@@ -69,6 +73,7 @@ describe Committee::Test::Methods do
       # Note we don't warn here because this is a recent deprecation and
       # passing a schema object will not be a huge performance hit. We should
       # probably start warning on the next version.
+      mock(Committee).warn_deprecated.with_any_args.times(3)
 
       stub(self).committee_schema { nil }
       stub(self).schema_contents do


### PR DESCRIPTION
Now method.rb depends on JSON Hyper-Schema structre.
So we need change for OpenAPI3.

In OpenAPI3 branch we refactoring abstruct schema object, so we don't need know detail structre.
We can change method.rb like this code.
https://github.com/interagent/committee/blob/485a863ecade369e942528d1ab769ddf829d57cb/lib/committee/test/methods.rb

And in 3.0, we should use Schema object.
https://github.com/interagent/committee#set-committeedriversschema-object-for-middleware
The test method should use Schema object too so we deprecated other methods and drop in 3.0.