### PR TITLE
Prefer path which has fewer matches on Committee::Router#find_link

### DIFF
--- a/lib/committee/router.rb
+++ b/lib/committee/router.rb
@@ -16,15 +16,13 @@ module Committee
 
     def find_link(method, path)
       path = path.gsub(@prefix_regexp, "") if @prefix
-      if method_routes = @schema.routes[method]
-        method_routes.each do |pattern, link|
-          if matches = pattern.match(path)
-            hash = Hash[matches.names.zip(matches.captures)]
-            return link, hash
-          end
+      (@schema.routes[method] || []).map do |pattern, link|
+        if matches = pattern.match(path)
+          [link, Hash[matches.names.zip(matches.captures)]]
+        else
+          nil
         end
-      end
-      nil
+      end.compact.first
     end
 
     def find_request_link(request)

--- a/lib/committee/router.rb
+++ b/lib/committee/router.rb
@@ -18,6 +18,7 @@ module Committee
       path = path.gsub(@prefix_regexp, "") if @prefix
       (@schema.routes[method] || []).map do |pattern, link|
         if matches = pattern.match(path)
+          # prefer path which has fewer matches (eg. `/pets/dog` than `/pets/{uuid}` for path `/pets/dog` )
           [matches.captures.size, link, Hash[matches.names.zip(matches.captures)]]
         else
           nil

--- a/lib/committee/router.rb
+++ b/lib/committee/router.rb
@@ -16,14 +16,15 @@ module Committee
 
     def find_link(method, path)
       path = path.gsub(@prefix_regexp, "") if @prefix
-      (@schema.routes[method] || []).map do |pattern, link|
+      link_with_matches = (@schema.routes[method] || []).map do |pattern, link|
         if matches = pattern.match(path)
           # prefer path which has fewer matches (eg. `/pets/dog` than `/pets/{uuid}` for path `/pets/dog` )
           [matches.captures.size, link, Hash[matches.names.zip(matches.captures)]]
         else
           nil
         end
-      end.compact.sort.first&.slice(1, 2)
+      end.compact.sort.first
+      link_with_matches.nil? ? nil : link_with_matches.slice(1, 2)
     end
 
     def find_request_link(request)

--- a/lib/committee/router.rb
+++ b/lib/committee/router.rb
@@ -18,11 +18,11 @@ module Committee
       path = path.gsub(@prefix_regexp, "") if @prefix
       (@schema.routes[method] || []).map do |pattern, link|
         if matches = pattern.match(path)
-          [link, Hash[matches.names.zip(matches.captures)]]
+          [matches.captures.size, link, Hash[matches.names.zip(matches.captures)]]
         else
           nil
         end
-      end.compact.first
+      end.compact.sort.first&.slice(1, 2)
     end
 
     def find_request_link(request)

--- a/test/data/openapi2/petstore-expanded.json
+++ b/test/data/openapi2/petstore-expanded.json
@@ -161,6 +161,29 @@
           }
         }
       }
+    },
+    "/pets/dog": {
+      "get": {
+        "description": "Returns pets which are dogs",
+        "operationId": "find pets which are dogs",
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -44,6 +44,7 @@ describe Committee::Router do
   it "provides named parameters" do
     link, param_matches = open_api_2_router.find_link("GET", "/api/pets/fido")
     refute_nil link
+    assert_equal '/api/pets/{id}', link.href
     assert_equal({ "id" => "fido" }, param_matches)
   end
 
@@ -51,6 +52,12 @@ describe Committee::Router do
     link, param_matches = open_api_2_router.find_link("GET", "/api/pets")
     refute_nil link
     assert_equal({}, param_matches)
+  end
+
+  it "finds a path which has fewer matches" do
+    link, _ = open_api_2_router.find_link("GET", "/api/pets/dog")
+    refute_nil link
+    assert_equal '/api/pets/dog', link.href
   end
 
   def hyper_schema_router(options = {})


### PR DESCRIPTION
# Issue
`Committee::Router#find_link` can not find expected path on following example.

```json
{
  "swagger": "2.0",
  "paths": {
    "/pets/{uuid}": {
      "get": {  }
    },
    "/pets/dog": {
      "get": {  }
    },
  }
}
```

```ruby
Committee::Router.new.find_link('get', '/pets/dog')
# got: Link instance for '/pets/{uuid}'
# expected: Link instance for '/pets/dog'
```

# This PR
When multiple links are matched on `Committee::Router#find_link`, return the path which has fewest matches.

If this PR looks good, I'll write some tests before merging. Thanks.