### PR TITLE
Change to coerce form params recursively

### DIFF
--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -46,6 +46,7 @@ module Committee::Middleware
         allow_query_params: @allow_query_params,
         coerce_form_params: @coerce_form_params,
         optimistic_json:    @optimistic_json,
+        coerce_recursive:   @coerce_recursive,
         schema:             link ? link.schema : nil
       ).call
 

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -7,6 +7,7 @@ module Committee
       @allow_query_params = options[:allow_query_params]
       @coerce_form_params = options[:coerce_form_params]
       @optimistic_json    = options[:optimistic_json]
+      @coerce_recursive   = options[:coerce_recursive]
       @schema             = options[:schema]
     end
 
@@ -31,7 +32,7 @@ module Committee
         p = @request.POST
 
         if @coerce_form_params && @schema
-          Committee::StringParamsCoercer.new(p, @schema).call!
+          Committee::StringParamsCoercer.new(p, @schema, coerce_recursive: @coerce_recursive).call!
         end
 
         p


### PR DESCRIPTION
## Issue

Form params is not recursively coerced
even if `coerce_recursive: true` was specified for `Committee :: MiddRequestValidation`

## Changes

I changed to pass `coerce_recursive` attribute to
`Committee::RequestUnpacker` and `Committee::StringParamsCoercer`.