### PR TITLE
initialize option fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ Committee is tested on the following MRI versions:
 ## Committee::Middleware::RequestValidation
 
 ``` ruby
-json = JSON.parse(File.read(...))
-schema = Committee::Drivers::HyperSchema.new.parse(json)
-use Committee::Middleware::RequestValidation, schema: schema
+schema = Committee::Drivers::load_from_json('docs/schema.json')
+use Committee::Middleware::RequestValidation, schema: schema, strict: false
 ```
 
 This piece of middleware validates the parameters of incoming requests to make sure that they're formatted according to the constraints imposed by a particular schema.
@@ -71,7 +70,7 @@ $ curl -X POST http://localhost:9292/apps -H "Content-Type: application/json" -d
 ## Committee::Middleware::Stub
 
 ``` ruby
-use Committee::Middleware::Stub, schema: JSON.parse(File.read(...))
+use Committee::Middleware::Stub, schema: Committee::Drivers::load_from_json('docs/schema.json')
 ```
 
 This piece of middleware intercepts any routes that are in the JSON Schema, then builds and returns an appropriate response for them.
@@ -125,7 +124,7 @@ committee-stub -p <port> <path to JSON schema>
 ## Committee::Middleware::ResponseValidation
 
 ``` ruby
-use Committee::Middleware::ResponseValidation, schema: JSON.parse(File.read(...))
+use Committee::Middleware::ResponseValidation, schema: Committee::Drivers::load_from_json('docs/schema.json')
 ```
 
 This piece of middleware validates the contents of the response received from up the stack for any route that matches the JSON Schema. A hyper-schema link's `targetSchema` property is used to determine what a valid response looks like.
@@ -144,7 +143,7 @@ Given a simple Sinatra app that responds for an endpoint in an incomplete fashio
 require "committee"
 require "sinatra"
 
-use Committee::Middleware::ResponseValidation, schema: JSON.parse(File.read("..."))
+use Committee::Middleware::ResponseValidation, schema: Committee::Drivers::load_from_json('docs/schema.json')
 
 get "/apps" do
   content_type :json
@@ -241,7 +240,7 @@ end
 ## Updater for version 3.x from version 2.x
 
 ### Set Committee::Drivers::Schema object for middleware
-schema option support JSON object and Sting and Hash object like this.  
+The schema option support JSON object and Sting and Hash object in version 2.x like this.  
 
 ```ruby
 # valid
@@ -260,9 +259,29 @@ Because 3.x support other schema and we can't define which parser we use.
 So please wrap Committee::Drivers::Schema like this.   
 
 ```ruby
+# auto select Hyper-Schema/OpenAPI2 from file
+use Committee::Middleware::RequestValidation, schema: Committee::Drivers::load_from_json('docs/schema.json')
+
+# auto select Hyper-Schema/OpenAPI2 from hash
+json = JSON.parse(File.read('docs/schema.json'))
+use Committee::Middleware::RequestValidation, schema: Committee::Drivers::load_data(json)
+
+# manual select
 json = JSON.parse(File.read(...))
 schema = Committee::Drivers::HyperSchema.new.parse(json)
 use Committee::Middleware::RequestValidation, schema: schema
+```
+
+The auto select algorithm like this.
+
+```ruby
+hash = JSON.load(json_path)
+
+if hash['swagger'] == '2.0' # OpenAPI2 require swagger key
+  return Committee::Drivers::OpenAPI2.new.parse(hash)
+else 
+  return Committee::Drivers::HyperSchema.new.parse(hash)
+end
 ```
 
 ### Change Test Assertions
@@ -272,11 +291,9 @@ This method should return same data in ResponseValidation option.
 
 ```ruby
 def committee_options
-  json = JSON.parse(File.read("./my-schema.json"))
-  schema = Committee::Drivers::HyperSchema.new.parse(json)
+  schema = Committee::Drivers::load_from_json('docs/schema.json')
 
   {schema: schema, prefix: "/v1"}
-  # {open_api_3: schema, prefix: "/v1"}
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Committee is tested on the following MRI versions:
 ## Committee::Middleware::RequestValidation
 
 ``` ruby
-schema = Committee::Drivers::load_from_json('docs/schema.json')
-use Committee::Middleware::RequestValidation, schema: schema, strict: false
+use Committee::Middleware::RequestValidation, json_file: 'docs/schema.json', strict: false
 ```
 
 This piece of middleware validates the parameters of incoming requests to make sure that they're formatted according to the constraints imposed by a particular schema.
@@ -70,7 +69,7 @@ $ curl -X POST http://localhost:9292/apps -H "Content-Type: application/json" -d
 ## Committee::Middleware::Stub
 
 ``` ruby
-use Committee::Middleware::Stub, schema: Committee::Drivers::load_from_json('docs/schema.json')
+use Committee::Middleware::Stub, json_file: 'docs/schema.json'
 ```
 
 This piece of middleware intercepts any routes that are in the JSON Schema, then builds and returns an appropriate response for them.
@@ -124,7 +123,7 @@ committee-stub -p <port> <path to JSON schema>
 ## Committee::Middleware::ResponseValidation
 
 ``` ruby
-use Committee::Middleware::ResponseValidation, schema: Committee::Drivers::load_from_json('docs/schema.json')
+use Committee::Middleware::ResponseValidation, json_file: 'docs/schema.json'
 ```
 
 This piece of middleware validates the contents of the response received from up the stack for any route that matches the JSON Schema. A hyper-schema link's `targetSchema` property is used to determine what a valid response looks like.
@@ -143,7 +142,7 @@ Given a simple Sinatra app that responds for an endpoint in an incomplete fashio
 require "committee"
 require "sinatra"
 
-use Committee::Middleware::ResponseValidation, schema: Committee::Drivers::load_from_json('docs/schema.json')
+use Committee::Middleware::ResponseValidation, json_file: 'docs/schema.json'
 
 get "/apps" do
   content_type :json
@@ -260,7 +259,7 @@ So please wrap Committee::Drivers::Schema like this.
 
 ```ruby
 # auto select Hyper-Schema/OpenAPI2 from file
-use Committee::Middleware::RequestValidation, schema: Committee::Drivers::load_from_json('docs/schema.json')
+use Committee::Middleware::RequestValidation, json_file: 'docs/schema.json'
 
 # auto select Hyper-Schema/OpenAPI2 from hash
 json = JSON.parse(File.read('docs/schema.json'))

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -13,6 +13,27 @@ module Committee
       end
     end
 
+    # load and build drive from JSON file
+    # @param [String] filepath
+    # @return [Committee::Driver]
+    def self.load_from_json(filepath)
+      json = JSON.parse(File.read(filepath))
+      load_from_data(json)
+    end
+
+    # load and build drive from Hash object
+    # @param [Hash] hash
+    # @return [Committee::Driver]
+    def self.load_from_data(hash)
+      driver = if hash['swagger'] == '2.0'
+                 Committee::Drivers::OpenAPI2.new
+               else
+                 Committee::Drivers::HyperSchema.new
+               end
+
+      driver.parse(hash)
+    end
+
     # Driver is a base class for driver implementations.
     class Driver
       # Whether parameters that were form-encoded will be coerced by default.

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -7,8 +7,7 @@ module Committee::Middleware
       @params_key = options[:params_key] || "committee.params"
       @headers_key = options[:headers_key] || "committee.headers"
       @raise = options[:raise]
-      @schema = get_schema(options[:schema] ||
-        raise(ArgumentError, "Committee: need option `schema`"))
+      @schema = get_schema(options)
 
       @router = Committee::Router.new(@schema,
         prefix: options[:prefix]
@@ -36,7 +35,14 @@ module Committee::Middleware
     # input to be a string, a data hash, or a JsonSchema::Schema. In the former
     # two cases we just parse as if we were sent hyper-schema. In the latter,
     # we have the hyper-schema driver wrap it in a new Committee object.
-    def get_schema(schema)
+    def get_schema(options)
+      schema = options[:schema]
+      unless schema
+        schema = Committee::Drivers::load_from_json(options[:json_file]) if options[:json_file]
+
+        raise(ArgumentError, "Committee: need option `schema` or json_file") unless schema
+      end
+
       # These are in a separately conditional ladder so that we only show the
       # user one warning.
       if schema.is_a?(String)

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -19,6 +19,35 @@ describe Committee::Drivers do
     end
     assert_equal %{Committee: unknown driver "blueprint".}, e.message
   end
+
+
+  describe 'load_from_json(filepath)' do
+    it 'load OpenAPI2' do
+      s = Committee::Drivers.load_from_json(open_api_2_filepath)
+      assert_kind_of Committee::Drivers::Schema, s
+      assert_kind_of Committee::Drivers::OpenAPI2::Schema, s
+    end
+
+    it 'load Hyper-Schema' do
+      s = Committee::Drivers.load_from_json(hyper_schema_filepath)
+      assert_kind_of Committee::Drivers::Schema, s
+      assert_kind_of Committee::Drivers::HyperSchema::Schema, s
+    end
+  end
+
+  describe 'load_from_data(filepath)' do
+    it 'load OpenAPI2' do
+      s = Committee::Drivers.load_from_data(open_api_2_data)
+      assert_kind_of Committee::Drivers::Schema, s
+      assert_kind_of Committee::Drivers::OpenAPI2::Schema, s
+    end
+
+    it 'load Hyper-Schema' do
+      s = Committee::Drivers.load_from_data(hyper_schema_data)
+      assert_kind_of Committee::Drivers::Schema, s
+      assert_kind_of Committee::Drivers::HyperSchema::Schema, s
+    end
+  end
 end
 
 describe Committee::Drivers::Driver do

--- a/test/middleware/base_test.rb
+++ b/test/middleware/base_test.rb
@@ -69,6 +69,18 @@ describe Committee::Middleware::Base do
       "of Committee::Drivers::Schema.", e.message
   end
 
+  describe 'initialize option' do
+    it "json file option with hyper-schema" do
+      b = Committee::Middleware::Base.new(nil, json_file: hyper_schema_filepath)
+      assert_kind_of Committee::Drivers::HyperSchema::Schema, b.instance_variable_get(:@schema)
+    end
+
+    it "json file option with OpenAPI2" do
+      b = Committee::Middleware::Base.new(nil, json_file: open_api_2_filepath)
+      assert_kind_of Committee::Drivers::OpenAPI2::Schema, b.instance_variable_get(:@schema)
+    end
+  end
+
   private
 
   def new_rack_app(options = {})

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,10 +62,18 @@ end
 
 # Don't cache this because we'll often manipulate the created hash in tests.
 def hyper_schema_data
-  JSON.parse(File.read("./test/data/hyperschema/paas.json"))
+  JSON.parse(File.read(hyper_schema_filepath))
 end
 
 # Don't cache this because we'll often manipulate the created hash in tests.
 def open_api_2_data
-  JSON.parse(File.read("./test/data/openapi2/petstore-expanded.json"))
+  JSON.parse(File.read(open_api_2_filepath))
+end
+
+def hyper_schema_filepath
+  "./test/data/hyperschema/paas.json"
+end
+
+def open_api_2_filepath
+  "./test/data/openapi2/petstore-expanded.json"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,17 +47,11 @@ ValidPet = {
 }.freeze
 
 def hyper_schema
-  @hyper_schema ||= begin
-    driver = Committee::Drivers::HyperSchema.new
-    driver.parse(hyper_schema_data)
-  end
+  @hyper_schema ||= Committee::Drivers.load_from_json(hyper_schema_filepath)
 end
 
 def open_api_2_schema
-  @open_api_2_schema ||= begin
-    driver = Committee::Drivers::OpenAPI2.new
-    driver.parse(open_api_2_data)
-  end
+  @open_api_2_schema ||= Committee::Drivers.load_from_data(open_api_2_data)
 end
 
 # Don't cache this because we'll often manipulate the created hash in tests.


### PR DESCRIPTION
We deprecated passing string data in this PR (https://github.com/interagent/committee/pull/147).
Because OpenAPI3 support json and yaml so we can't auto parse.

But, we can auto select from parsed data.
So we can support auto select if the user choose json or yaml.

(I'll implement loading yaml file option on OpenAPI3 branch)