### PR TITLE
change validate_errors to validate_success_only

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Options:
 * `error_class`: Specifies the class to use for formatting and outputting validation errors (defaults to `Committee::ValidationError`)
 * `prefix`: Mounts the middleware to respond at a configured prefix.
 * `raise`: Raise an exception on error instead of responding with a generic error body (defaults to `false`).
-* `validate_errors`: Also validate non-2xx responses (defaults to `false`).
+* `validate_errors`: Also validate non-2xx responses (defaults to `false`). *deprecated please use validate_success_only.*
+* `validate_success_only`: Also validate non-2xx responses only (defaults to `true`). This is same mean validate_errors=false.
 * `error_handler`: A proc which will be called when error occurs. Take an Error instance as first argument.
 
 Given a simple Sinatra app that responds for an endpoint in an incomplete fashion:

--- a/lib/committee/response_validator.rb
+++ b/lib/committee/response_validator.rb
@@ -1,18 +1,18 @@
 module Committee
   class ResponseValidator
-    attr_reader :validate_errors
+    attr_reader :validate_success_only
 
     def initialize(link, options = {})
       @link = link
-      @validate_errors = options[:validate_errors]
+      @validate_success_only = options[:validate_success_only]
 
       @validator = JsonSchema::Validator.new(target_schema(link))
     end
 
     def self.validate?(status, options = {})
-      validate_errors = options[:validate_errors]
+      validate_success_only = options[:validate_success_only]
 
-      status != 204 and validate_errors || (200...300).include?(status)
+      status != 204 and !validate_success_only || (200...300).include?(status)
     end
 
     def call(status, headers, data)
@@ -41,7 +41,7 @@ module Committee
         return if data == nil
       end
 
-      if self.class.validate?(status, validate_errors: validate_errors) && !@validator.validate(data)
+      if self.class.validate?(status, validate_success_only: validate_success_only) && !@validator.validate(data)
         errors = JsonSchema::SchemaError.aggregate(@validator.errors).join("\n")
         raise InvalidResponse, "Invalid response.\n\n#{errors}"
       end

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -41,9 +41,20 @@ describe Committee::Middleware::ResponseValidation do
     assert_equal 404, last_response.status
   end
 
-  it "optionally validates non-2xx invalid responses" do
+  it "optionally validates non-2xx invalid responses and deprecated option" do
+    mock(Committee).warn_deprecated.with_any_args
+
     @app = new_rack_app("", {}, app_status: 404, validate_errors: true,
-      schema: hyper_schema)
+                        schema: hyper_schema)
+
+    get "/apps"
+    assert_equal 500, last_response.status
+    assert_match(/valid JSON/i, last_response.body)
+  end
+
+  it "optionally validates non-2xx invalid responses" do
+    @app = new_rack_app("", {}, app_status: 404, validate_success_only: false,
+                        schema: hyper_schema)
 
     get "/apps"
     assert_equal 500, last_response.status


### PR DESCRIPTION
The validate_erros option validate 1xx and 3xx status code but it's not error status code.
So we should deprecated and change option name.

This change is deprecated only and we'll change new option when 3.x released.

(We can all status code schema in OpenAPI3 so it will be more large problem)