### PR TITLE
bundler install command fix for travis change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ rvm:
   - 2.6.0
   - ruby-head
 
+before_install:
+  - gem install bundler -v '< 2'
+
 cache: bundler
 
 script: bundle exec rake


### PR DESCRIPTION
travis.ci support bundler 2 so old ruby version needs add install command.
https://docs.travis-ci.com/user/languages/ruby/#bundler-20