### PR TITLE
support datetime format validation

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json_schema", "~> 0.14", ">= 0.14.3"
 
   s.add_dependency "rack", ">= 1.5"
-  s.add_dependency "openapi_parser", ">= 0.2.0"
+  s.add_dependency "openapi_parser", ">= 0.2.2"
 
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rack-test", "~> 0.6"

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -95,19 +95,16 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
-  # TODO: support date-time object format check
-=begin
   it "passes given an invalid datetime string with coerce_date_times enabled" do
     @app = new_rack_app(open_api_3: open_api_3_schema, coerce_date_times: true)
     params = {
         "datetime_string" => "invalid_datetime_format"
     }
-    get "/string_params_coercer", JSON.generate(params)
+    get "/string_params_coercer", params
 
     assert_equal 400, last_response.status
-    assert_match(/invalid request/i, last_response.body)
+    assert_match(/invalid_datetime/i, last_response.body)
   end
-=end
 
   it "passes a nested object with recursive option" do
     params = {


### PR DESCRIPTION
openapi_parser 0.2.2 support datetime format validation

don't merge