### PR TITLE
support filepath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ So please set filepath or loaded data.
 ```ruby
 # auto select Hyper-Schema/OpenAPI2 from file
 use Committee::Middleware::RequestValidation, filepath: 'docs/schema.json' # using file extension
-use Committee::Middleware::RequestValidation, json_file: 'docs/schema.json'
 
 # auto select Hyper-Schema/OpenAPI2 from hash
 json = JSON.parse(File.read('docs/schema.json'))

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Committee is tested on the following MRI versions:
 ## Committee::Middleware::RequestValidation
 
 ``` ruby
-use Committee::Middleware::RequestValidation, json_file: 'docs/schema.json', strict: false
+use Committee::Middleware::RequestValidation, filepath: 'docs/schema.json', coerce_date_times: true
 ```
 
 This piece of middleware validates the parameters of incoming requests to make sure that they're formatted according to the constraints imposed by a particular schema.
@@ -69,7 +69,7 @@ $ curl -X POST http://localhost:9292/apps -H "Content-Type: application/json" -d
 ## Committee::Middleware::Stub
 
 ``` ruby
-use Committee::Middleware::Stub, json_file: 'docs/schema.json'
+use Committee::Middleware::Stub, filepath: 'docs/schema.json'
 ```
 
 This piece of middleware intercepts any routes that are in the JSON Schema, then builds and returns an appropriate response for them.
@@ -123,7 +123,7 @@ committee-stub -p <port> <path to JSON schema>
 ## Committee::Middleware::ResponseValidation
 
 ``` ruby
-use Committee::Middleware::ResponseValidation, json_file: 'docs/schema.json'
+use Committee::Middleware::ResponseValidation, filepath: 'docs/schema.json'
 ```
 
 This piece of middleware validates the contents of the response received from up the stack for any route that matches the JSON Schema. A hyper-schema link's `targetSchema` property is used to determine what a valid response looks like.
@@ -143,7 +143,7 @@ Given a simple Sinatra app that responds for an endpoint in an incomplete fashio
 require "committee"
 require "sinatra"
 
-use Committee::Middleware::ResponseValidation, json_file: 'docs/schema.json'
+use Committee::Middleware::ResponseValidation, filepath: 'docs/schema.json'
 
 get "/apps" do
   content_type :json
@@ -255,11 +255,12 @@ use Committee::Middleware::RequestValidation, schema: 'json string'
 ```
 
 But we don't support version 3.x.  
-Because 3.x support other schema and we can't define which parser we use.  
-So please wrap Committee::Drivers::Schema like this.   
+Because 3.x support yaml and json, we can't decide which should be use.  
+So please set filepath or loaded data.
 
 ```ruby
 # auto select Hyper-Schema/OpenAPI2 from file
+use Committee::Middleware::RequestValidation, filepath: 'docs/schema.json' # using file extension
 use Committee::Middleware::RequestValidation, json_file: 'docs/schema.json'
 
 # auto select Hyper-Schema/OpenAPI2 from hash
@@ -291,9 +292,7 @@ This method should return same data in ResponseValidation option.
 
 ```ruby
 def committee_options
-  schema = Committee::Drivers::load_from_json('docs/schema.json')
-
-  {schema: schema, prefix: "/v1"}
+  @committee_options ||= {schema: Committee::Drivers::load_from_file('docs/schema.json'), prefix: "/v1"}
 end
 ```
 

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -34,6 +34,13 @@ module Committee
       driver.parse(hash)
     end
 
+    # load and build drive from file
+    # @param [String] filepath
+    # @return [Committee::Driver]
+    def self.load_from_file(filepath)
+      load_from_json(filepath)
+    end
+
     # Driver is a base class for driver implementations.
     class Driver
       # Whether parameters that were form-encoded will be coerced by default.

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -38,6 +38,7 @@ module Committee::Middleware
     def get_schema(options)
       schema = options[:schema]
       unless schema
+        schema = Committee::Drivers::load_from_json(options[:filepath]) if options[:filepath]
         schema = Committee::Drivers::load_from_json(options[:json_file]) if options[:json_file]
 
         raise(ArgumentError, "Committee: need option `schema` or json_file") unless schema

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -38,10 +38,9 @@ module Committee::Middleware
     def get_schema(options)
       schema = options[:schema]
       unless schema
-        schema = Committee::Drivers::load_from_json(options[:filepath]) if options[:filepath]
-        schema = Committee::Drivers::load_from_json(options[:json_file]) if options[:json_file]
+        schema = Committee::Drivers::load_from_file(options[:filepath]) if options[:filepath]
 
-        raise(ArgumentError, "Committee: need option `schema` or json_file") unless schema
+        raise(ArgumentError, "Committee: need option `schema` or filepath") unless schema
       end
 
       # These are in a separately conditional ladder so that we only show the

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -20,6 +20,19 @@ describe Committee::Drivers do
     assert_equal %{Committee: unknown driver "blueprint".}, e.message
   end
 
+  describe 'load_from_file(filepath)' do
+    it 'load OpenAPI2' do
+      s = Committee::Drivers.load_from_file(open_api_2_filepath)
+      assert_kind_of Committee::Drivers::Schema, s
+      assert_kind_of Committee::Drivers::OpenAPI2::Schema, s
+    end
+
+    it 'load Hyper-Schema' do
+      s = Committee::Drivers.load_from_file(hyper_schema_filepath)
+      assert_kind_of Committee::Drivers::Schema, s
+      assert_kind_of Committee::Drivers::HyperSchema::Schema, s
+    end
+  end
 
   describe 'load_from_json(filepath)' do
     it 'load OpenAPI2' do

--- a/test/middleware/base_test.rb
+++ b/test/middleware/base_test.rb
@@ -70,13 +70,13 @@ describe Committee::Middleware::Base do
   end
 
   describe 'initialize option' do
-    it "json file option with hyper-schema" do
+    it "filepath option with hyper-schema" do
       b = Committee::Middleware::Base.new(nil, filepath: hyper_schema_filepath)
       assert_kind_of Committee::Drivers::HyperSchema::Schema, b.instance_variable_get(:@schema)
     end
 
-    it "json file option with OpenAPI2" do
-      b = Committee::Middleware::Base.new(nil, json_file: open_api_2_filepath)
+    it "filepath option with OpenAPI2" do
+      b = Committee::Middleware::Base.new(nil, filepath: open_api_2_filepath)
       assert_kind_of Committee::Drivers::OpenAPI2::Schema, b.instance_variable_get(:@schema)
     end
   end

--- a/test/middleware/base_test.rb
+++ b/test/middleware/base_test.rb
@@ -71,7 +71,7 @@ describe Committee::Middleware::Base do
 
   describe 'initialize option' do
     it "json file option with hyper-schema" do
-      b = Committee::Middleware::Base.new(nil, json_file: hyper_schema_filepath)
+      b = Committee::Middleware::Base.new(nil, filepath: hyper_schema_filepath)
       assert_kind_of Committee::Drivers::HyperSchema::Schema, b.instance_variable_get(:@schema)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,7 @@ ValidPet = {
 }.freeze
 
 def hyper_schema
-  @hyper_schema ||= Committee::Drivers.load_from_json(hyper_schema_filepath)
+  @hyper_schema ||= Committee::Drivers.load_from_file(hyper_schema_filepath)
 end
 
 def open_api_2_schema


### PR DESCRIPTION
I add loading json file initialize option.
https://github.com/interagent/committee/pull/180

But we can decide it's JSON or YAML using file extension.
So we can provide auto load option.

2.x support JSON file only, so it's useless method call but it will be good code on 3.x branch.