### PR TITLE
check content type bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,6 @@ use Committee::Middleware::RequestValidation, schema: schema
 The auto select algorithm like this.
 
 ```ruby
-
 hash = JSON.load(json_path)
 
 if hash['openapi']&.start_with?('3.') # OpenAPI3 specification require this key and version

--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -55,8 +55,14 @@ module Committee
       ret
     end
 
-    def request_bodies_media_type(request_content_type)
-      request_operation.operation_object&.request_body&.select_media_type(request_content_type)
+    def valid_request_content_type?(content_type)
+      if (request_body = request_operation.operation_object&.request_body)
+        !request_body.select_media_type(content_type).nil?
+      else
+        # if not exist request body object, all content_type allow.
+        # because request body object required content field so when it exists there're content type definition.
+        true
+      end
     end
 
     private

--- a/lib/committee/schema_validator/open_api_3/request_validator.rb
+++ b/lib/committee/schema_validator/open_api_3/request_validator.rb
@@ -19,9 +19,7 @@ module Committee
     def check_content_type(request, content_type)
       # support post, put, patch only
       return true unless request.post? || request.put? || request.patch?
-
-      media_type = @operation_object.request_bodies_media_type(content_type)
-      return true if media_type
+      return true if @operation_object.valid_request_content_type?(content_type)
 
       raise Committee::InvalidRequest, %{"Content-Type" request header must be set to "#{@operation_object}".}
     end

--- a/test/schema_validator/open_api_3/request_validator_test.rb
+++ b/test/schema_validator/open_api_3/request_validator_test.rb
@@ -28,6 +28,16 @@ describe Committee::SchemaValidator::OpenAPI3::RequestValidator do
       assert_equal 200, last_response.status
     end
 
+    it "if not exist requsetBody definition, skip content_type check" do
+      @app = new_rack_app(check_content_type: true, schema: open_api_3_schema)
+      params = {
+          "string_post_1" => "cloudnasium"
+      }
+      header "Content-Type", "application/json"
+      patch "/validate_no_parameter", JSON.generate(params)
+      assert_equal 200, last_response.status
+    end
+
     def new_rack_app(options = {})
       Rack::Builder.new {
         use Committee::Middleware::RequestValidation, options


### PR DESCRIPTION
When not exist Request Body Object, raise 400 error.
But if not exist definition, we should allow all data so I change it's valid request.

Please review only because this base branch isn't 3-0