### PR TITLE
3.0.0.beta release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Unreleased
+	Support full committee options in OpenAPI3
 	Fix bug when non defined link with form content type and coerce option (#173)
-	support check_content_type option for OpenAPI3 (#174)
+	Support check_content_type option for OpenAPI3 (#174)
 
 3.0.0.alpha 2018-12-26
 	OpenAPI 3.0 support (#164)

--- a/README.md
+++ b/README.md
@@ -139,13 +139,20 @@ use Committee::Middleware::ResponseValidation, filepath: 'docs/schema.json'
 
 This piece of middleware validates the contents of the response received from up the stack for any route that matches the JSON Schema. A hyper-schema link's `targetSchema` property is used to determine what a valid response looks like.
 
-Options:
+Option values and defaults:
 
-* `error_class`: Specifies the class to use for formatting and outputting validation errors (defaults to `Committee::ValidationError`)
-* `prefix`: Mounts the middleware to respond at a configured prefix.
-* `raise`: Raise an exception on error instead of responding with a generic error body (defaults to `false`).
-* `validate_success_only`: Also validate non-2xx responses only (defaults to `true`). This is same mean validate_errors=false in 2.x.
-* `error_handler`: A proc which will be called when error occurs. Take an Error instance as first argument.
+| name | Hyper-Schema | OpenAPI3 | Description |
+|-----------:|------------:|------------:| :------------ |
+|validate_success_only| true | false | Also validate non-2xx responses only. |
+|raise| false | false | Raise an exception on error instead of responding with a generic error body |
+
+No boolean option values:
+
+| name | allowed object type | Hyper-Schema | OpenAPI3 | Description |
+|-----------:|------------:|------------:|------------:| :------------ |
+|prefix| String | support | support | Mounts the middleware to respond at a configured prefix. |
+|error_class| StandardError | support | support | Specifies the class to use for formatting and outputting validation errors (defaults to `Committee::ValidationError`). |
+|error_handler| Proc Object | support | support | A proc which will be called when error occurs. Take an Error instance as first argument. |
 
 Given a simple Sinatra app that responds for an endpoint in an incomplete fashion:
 
@@ -250,14 +257,14 @@ end
 Committee auto select parser from definition, so you don't care.
 
 ```ruby
-use Committee::Middleware::RequestValidation, filepath: 'open_api_3/schema.yml'
+use Committee::Middleware::RequestValidation, filepath: 'open_api_3/schema.yaml'
 ```
 
 If you want to select manualy, please pass 'openapi_parser' object to committee.
 This gem added gem dependency so you can use always
 
 ```ruby
-open_api = OpenAPIParser.parse(YAML.load_file('open_api_3/schema.yml'))
+open_api = OpenAPIParser.parse(YAML.load_file('open_api_3/schema.yaml'))
 schema = Committee::Drivers::OpenAPI3.new.parse(open_api)
 use Committee::Middleware::RequestValidation, schema: schema
 ```
@@ -271,6 +278,18 @@ use Committee::Middleware::RequestValidation, schema: schema
   * Always set coerce_recursive=true
 
 ## Updater for version 3.x from version 2.x
+
+We recommend upgrade this step.
+There are many breaking changes in 3.x.
+But we add deprecated warning and migration path in 2.x.
+So you can harmless update using latest 2.x.
+
+1. use latest 2.x version
+2. fix all deprecated warning (see below)
+3. update 3.0.x version
+4. (If you want to use OpenAPI3) use OpenAPI3
+
+It is detailed in the next section.
 
 ### Set Committee::Drivers::Schema object for middleware
 The schema option support JSON object and Sting and Hash object in version 2.x like this.  

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = "committee"
-  s.version       = "3.0.0.alpha"
+  s.version       = "3.0.0.beta"
 
   s.summary       = "A collection of Rack middleware to support JSON Schema."
 


### PR DESCRIPTION
Now ready for release 3.0.0.beta.  
This version support OpenAPI3 with all committee options and bugfx, merge 2.4.0 (https://github.com/interagent/committee/pull/197).

- [x] https://github.com/interagent/committee/pull/195
- [x] https://github.com/interagent/committee/pull/193
- [x] https://github.com/interagent/committee/pull/192
- [x] https://github.com/interagent/committee/pull/191
- [x] merge master to 3-0
- [x] release note