### PR TITLE
release 2.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,11 @@
 Unreleased
+	Add methods for harmless upgrade (#199, #195)
+	Support filepath option (#191)
+	Change change validate_errors option to validate_success_only (#187)
+	Bugfix for coerce_recursive option in request params (#162)
+	Path definition fewer matches in OpenAPI2 (#160)
+	Deprecated test method (#157)
+	Add `error_handler` option (#152)
 
 2.3.0 2018-11-15
 	Deprecate use of `JsonSchema::Schema` object (#147)

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = "committee"
-  s.version       = "2.3.0"
+  s.version       = "2.4.0"
 
   s.summary       = "A collection of Rack middleware to support JSON Schema."
 


### PR DESCRIPTION
I add bugfix and few fix for migration 3.x.  
So please release 2.4.0.

If there aren't bug and problem for migration 3.x, I think this version will be latest release in 2.x.

task
- [x] https://github.com/interagent/committee/pull/191
- [x] https://github.com/interagent/committee/pull/195
- [x] release note
- [x] bugfix