### PR TITLE
Incorrect error and warning messages

### DIFF
--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -68,8 +68,8 @@ module Committee::Middleware
       # Expect the type we want by now. If we don't have it, the user passed
       # something else non-standard in.
       if !schema.is_a?(Committee::Drivers::Schema)
-        raise ArgumentError, "Committee: schema expected to be a hash or " \
-          "an instance of Committee::Drivers::Schema."
+        raise ArgumentError, "Committee: schema expected to be an instance of " \
+          "Committee::Drivers::Schema."
       end
 
       schema
@@ -77,17 +77,17 @@ module Committee::Middleware
 
     def warn_json_schema_deprecated
       Committee.warn_deprecated("Committee: passing a JsonSchema::Schema to schema " \
-        "option is deprecated; please send a driver object instead.")
+        "option is deprecated; please send an instance of Committee::Drivers::Schema instead.")
     end
 
     def warn_hash_deprecated
       Committee.warn_deprecated("Committee: passing a hash to schema " \
-        "option is deprecated; please send a driver object instead.")
+        "option is deprecated; please send an instance of Committee::Drivers::Schema instead.")
     end
 
     def warn_string_deprecated
       Committee.warn_deprecated("Committee: passing a string to schema " \
-        "option is deprecated; please send a driver object instead.")
+        "option is deprecated; please send an instance of Committee::Drivers::Schema instead.")
     end
   end
 end

--- a/test/middleware/base_test.rb
+++ b/test/middleware/base_test.rb
@@ -65,8 +65,7 @@ describe Committee::Middleware::Base do
     e = assert_raises(ArgumentError) do
       post "/apps"
     end
-    assert_equal "Committee: schema expected to be a hash or an instance " +
-      "of Committee::Drivers::Schema.", e.message
+    assert_equal "Committee: schema expected to be an instance of Committee::Drivers::Schema.", e.message
   end
 
   describe 'initialize option' do


### PR DESCRIPTION
If I understand correctly, `schema:` option for Middleware object accepts an instance of Schema object as the name implies, but the error message and warning message are showing misleading phrases like
"please send a driver object instead" or
"schema expected to be a hash or an instance of Committee::Drivers::Schema".

Here's a quick fix on those messages.