### PR TITLE
Rename `filepath` to `schema_path`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Unreleased
 	Prefer path with fewest slugs when a request may route to resolve to multiple (#160)
 	Fix bug when using `coerce_recursive` in request parameters (#162)
 	Deprecated `validate_errors` option in favor of `validate_success_only` (#187)
-	Add `filepath` option (#191)
+	Add `schema_path` option (#191)
 	Add `request_object` and `response_data` to `Committee::Test::Methods` (#195)
 	Add `validate_success_only` option (#199)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Committee is tested on the following MRI versions:
 ## Committee::Middleware::RequestValidation
 
 ``` ruby
-use Committee::Middleware::RequestValidation, filepath: 'docs/schema.json', coerce_date_times: true
+use Committee::Middleware::RequestValidation, schema_path: 'docs/schema.json', coerce_date_times: true
 ```
 
 This piece of middleware validates the parameters of incoming requests to make sure that they're formatted according to the constraints imposed by a particular schema.
@@ -69,7 +69,7 @@ $ curl -X POST http://localhost:9292/apps -H "Content-Type: application/json" -d
 ## Committee::Middleware::Stub
 
 ``` ruby
-use Committee::Middleware::Stub, filepath: 'docs/schema.json'
+use Committee::Middleware::Stub, schema_path: 'docs/schema.json'
 ```
 
 This piece of middleware intercepts any routes that are in the JSON Schema, then builds and returns an appropriate response for them.
@@ -123,7 +123,7 @@ committee-stub -p <port> <path to JSON schema>
 ## Committee::Middleware::ResponseValidation
 
 ``` ruby
-use Committee::Middleware::ResponseValidation, filepath: 'docs/schema.json'
+use Committee::Middleware::ResponseValidation, schema_path: 'docs/schema.json'
 ```
 
 This piece of middleware validates the contents of the response received from up the stack for any route that matches the JSON Schema. A hyper-schema link's `targetSchema` property is used to determine what a valid response looks like.
@@ -143,7 +143,7 @@ Given a simple Sinatra app that responds for an endpoint in an incomplete fashio
 require "committee"
 require "sinatra"
 
-use Committee::Middleware::ResponseValidation, filepath: 'docs/schema.json'
+use Committee::Middleware::ResponseValidation, schema_path: 'docs/schema.json'
 
 get "/apps" do
   content_type :json
@@ -253,11 +253,11 @@ use Committee::Middleware::RequestValidation, schema: 'json string'
 
 But we don't support version 3.x.  
 Because 3.x support yaml and json, we can't decide which should be use.  
-So please set filepath or loaded data.
+So please set schema_path or loaded data.
 
 ```ruby
 # auto select Hyper-Schema/OpenAPI2 from file
-use Committee::Middleware::RequestValidation, filepath: 'docs/schema.json' # using file extension
+use Committee::Middleware::RequestValidation, schema_path: 'docs/schema.json' # using file extension
 
 # auto select Hyper-Schema/OpenAPI2 from hash
 json = JSON.parse(File.read('docs/schema.json'))

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -14,10 +14,10 @@ module Committee
     end
 
     # load and build drive from JSON file
-    # @param [String] filepath
+    # @param [String] schema_path
     # @return [Committee::Driver]
-    def self.load_from_json(filepath)
-      json = JSON.parse(File.read(filepath))
+    def self.load_from_json(schema_path)
+      json = JSON.parse(File.read(schema_path))
       load_from_data(json)
     end
 
@@ -35,10 +35,10 @@ module Committee
     end
 
     # load and build drive from file
-    # @param [String] filepath
+    # @param [String] schema_path
     # @return [Committee::Driver]
-    def self.load_from_file(filepath)
-      load_from_json(filepath)
+    def self.load_from_file(schema_path)
+      load_from_json(schema_path)
     end
 
     # Driver is a base class for driver implementations.

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -38,9 +38,9 @@ module Committee::Middleware
     def get_schema(options)
       schema = options[:schema]
       unless schema
-        schema = Committee::Drivers::load_from_file(options[:filepath]) if options[:filepath]
+        schema = Committee::Drivers::load_from_file(options[:schema_path]) if options[:schema_path]
 
-        raise(ArgumentError, "Committee: need option `schema` or filepath") unless schema
+        raise(ArgumentError, "Committee: need option `schema` or schema_path") unless schema
       end
 
       # These are in a separately conditional ladder so that we only show the

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -20,35 +20,35 @@ describe Committee::Drivers do
     assert_equal %{Committee: unknown driver "blueprint".}, e.message
   end
 
-  describe 'load_from_file(filepath)' do
+  describe 'load_from_file(schema_path)' do
     it 'load OpenAPI2' do
-      s = Committee::Drivers.load_from_file(open_api_2_filepath)
+      s = Committee::Drivers.load_from_file(open_api_2_schema_path)
       assert_kind_of Committee::Drivers::Schema, s
       assert_kind_of Committee::Drivers::OpenAPI2::Schema, s
     end
 
     it 'load Hyper-Schema' do
-      s = Committee::Drivers.load_from_file(hyper_schema_filepath)
+      s = Committee::Drivers.load_from_file(hyper_schema_schema_path)
       assert_kind_of Committee::Drivers::Schema, s
       assert_kind_of Committee::Drivers::HyperSchema::Schema, s
     end
   end
 
-  describe 'load_from_json(filepath)' do
+  describe 'load_from_json(schema_path)' do
     it 'load OpenAPI2' do
-      s = Committee::Drivers.load_from_json(open_api_2_filepath)
+      s = Committee::Drivers.load_from_json(open_api_2_schema_path)
       assert_kind_of Committee::Drivers::Schema, s
       assert_kind_of Committee::Drivers::OpenAPI2::Schema, s
     end
 
     it 'load Hyper-Schema' do
-      s = Committee::Drivers.load_from_json(hyper_schema_filepath)
+      s = Committee::Drivers.load_from_json(hyper_schema_schema_path)
       assert_kind_of Committee::Drivers::Schema, s
       assert_kind_of Committee::Drivers::HyperSchema::Schema, s
     end
   end
 
-  describe 'load_from_data(filepath)' do
+  describe 'load_from_data(schema_path)' do
     it 'load OpenAPI2' do
       s = Committee::Drivers.load_from_data(open_api_2_data)
       assert_kind_of Committee::Drivers::Schema, s

--- a/test/middleware/base_test.rb
+++ b/test/middleware/base_test.rb
@@ -69,13 +69,13 @@ describe Committee::Middleware::Base do
   end
 
   describe 'initialize option' do
-    it "filepath option with hyper-schema" do
-      b = Committee::Middleware::Base.new(nil, filepath: hyper_schema_filepath)
+    it "schema_path option with hyper-schema" do
+      b = Committee::Middleware::Base.new(nil, schema_path: hyper_schema_schema_path)
       assert_kind_of Committee::Drivers::HyperSchema::Schema, b.instance_variable_get(:@schema)
     end
 
-    it "filepath option with OpenAPI2" do
-      b = Committee::Middleware::Base.new(nil, filepath: open_api_2_filepath)
+    it "schema_path option with OpenAPI2" do
+      b = Committee::Middleware::Base.new(nil, schema_path: open_api_2_schema_path)
       assert_kind_of Committee::Drivers::OpenAPI2::Schema, b.instance_variable_get(:@schema)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,7 @@ ValidPet = {
 }.freeze
 
 def hyper_schema
-  @hyper_schema ||= Committee::Drivers.load_from_file(hyper_schema_filepath)
+  @hyper_schema ||= Committee::Drivers.load_from_file(hyper_schema_schema_path)
 end
 
 def open_api_2_schema
@@ -56,18 +56,18 @@ end
 
 # Don't cache this because we'll often manipulate the created hash in tests.
 def hyper_schema_data
-  JSON.parse(File.read(hyper_schema_filepath))
+  JSON.parse(File.read(hyper_schema_schema_path))
 end
 
 # Don't cache this because we'll often manipulate the created hash in tests.
 def open_api_2_data
-  JSON.parse(File.read(open_api_2_filepath))
+  JSON.parse(File.read(open_api_2_schema_path))
 end
 
-def hyper_schema_filepath
+def hyper_schema_schema_path
   "./test/data/hyperschema/paas.json"
 end
 
-def open_api_2_filepath
+def open_api_2_schema_path
   "./test/data/openapi2/petstore-expanded.json"
 end


### PR DESCRIPTION
@ota42y Sorry to be a pain, but would you mind if we renamed the
`filepath` to `schema_path`? I think this is better for two reasons:

1. We're specific about what type of file this points to. Its a
   "schema", which is a word that's broad enough to be used for
   Hyper-schema, OpenAPI 2, and OpenAPI 3.
2. I think the convention around use of underscores between words looks
   a little cleaner (i.e., `filepath` versus `file_path`).