### PR TITLE
Bump version to 3.0.0.beta2

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = "committee"
-  s.version       = "3.0.0.beta"
+  s.version       = "3.0.0.beta2"
 
   s.summary       = "A collection of Rack middleware to support JSON Schema."
 


### PR DESCRIPTION
We ended up changing the naming of the option `filepath` to
`schema_path` after `3.0.0.beta` was released. Here we release a new
version of the 3.0 line that has the new name in it to be consistent
with what's in 2.4.0