### PR TITLE
Fix pattern value

### DIFF
--- a/lib/committee/drivers/open_api_2.rb
+++ b/lib/committee/drivers/open_api_2.rb
@@ -177,7 +177,7 @@ module Committee::Drivers
 
               # validation: string
               param_schema.format = param_data["format"] unless param_data["format"].nil?
-              param_schema.pattern = param_data["pattern"] unless param_data["pattern"].nil?
+              param_schema.pattern = Regexp.new(param_data["pattern"]) unless param_data["pattern"].nil?
               param_schema.min_length = param_data["minLength"] unless param_data["minLength"].nil?
               param_schema.max_length = param_data["maxLength"] unless param_data["maxLength"].nil?
 

--- a/test/drivers/open_api_2_test.rb
+++ b/test/drivers/open_api_2_test.rb
@@ -307,7 +307,7 @@ describe Committee::Drivers::OpenAPI2::ParameterSchemaBuilder do
 
     assert_nil schema_data
     assert_equal "password", schema.properties["password"].format
-    assert_equal "[a-zA-Z0-9]+", schema.properties["password"].pattern
+    assert_equal Regexp.new("[a-zA-Z0-9]+"), schema.properties["password"].pattern
     assert_equal 6, schema.properties["password"].min_length
     assert_equal 30, schema.properties["password"].max_length
   end


### PR DESCRIPTION
Fix #207

I'm sorry.
Pattern value should be Regexp object.
ref: https://github.com/brandur/json_schema/blob/f07e6a8f9a608c132b6b2bb05793607e68005c9e/lib/json_schema/parser.rb#L244-L253