### PR TITLE
OpenAPI 3 merge request body to request parameter in GET request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 Unreleased
-
+	OpenAPI 3 merge request body to request parameter in GET request (#210)
 
 3.0.0.beta 2019-01-19
 	Support full committee options in OpenAPI3

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -17,7 +17,7 @@ class Committee::SchemaValidator
 
       request_schema_validation(request)
 
-      @operation_object&.coerce_request_parameter(request.env["rack.request.query_hash"], header(request), validator_option) if !request.GET.nil? && !request.env["rack.request.query_hash"].empty?
+      copy_coered_data_to_query_hash(request)
     end
 
     def response_validate(status, headers, response, test_method = false)
@@ -70,6 +70,14 @@ class Committee::SchemaValidator
           optimistic_json:    validator_option.optimistic_json,
           schema_validator:   self
       ).call
+    end
+
+    def copy_coered_data_to_query_hash(request)
+      return if request.env["rack.request.query_hash"].nil? || request.env["rack.request.query_hash"].empty?
+
+      request.env["rack.request.query_hash"].keys.each do |k|
+        request.env["rack.request.query_hash"][k] = request.env[validator_option.params_key][k]
+      end
     end
   end
 end

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -17,7 +17,7 @@ class Committee::SchemaValidator
 
       request_schema_validation(request)
 
-      copy_coered_data_to_query_hash(request)
+      copy_coerced_data_to_query_hash(request)
     end
 
     def response_validate(status, headers, response, test_method = false)
@@ -72,7 +72,7 @@ class Committee::SchemaValidator
       ).call
     end
 
-    def copy_coered_data_to_query_hash(request)
+    def copy_coerced_data_to_query_hash(request)
       return if request.env["rack.request.query_hash"].nil? || request.env["rack.request.query_hash"].empty?
 
       request.env["rack.request.query_hash"].keys.each do |k|

--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -20,13 +20,6 @@ module Committee
       request_operation.validate_path_params(options)
     end
 
-    def coerce_request_parameter(params, headers, validator_option)
-      options = build_openapi_parser_get_option(validator_option)
-      return unless options.coerce_value
-
-      request_operation.validate_request_parameter(params, headers, options)
-    end
-
     # @param [Boolean] strict when not content_type or status code definition, raise error
     def validate_response_params(status_code, headers, response_data, strict, check_header)
       request_body = OpenAPIParser::RequestOperation::ValidatableResponseBody.new(status_code, response_data, headers)

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -494,6 +494,20 @@ paths:
               description: integer
               schema:
                 type: integer
+  /get_body_test:
+    get:
+      description: get body test
+      parameters:
+      - name: datetime_string
+        in: query
+        required: true
+        schema:
+          type: string
+          format: date-time
+      responses:
+        '204':
+          description: no content
+
 components:
   schemas:
     nested_array:

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -42,6 +42,20 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
+  it "passes given a datetime and with coerce_date_times enabled on GET endpoint with request body(old behavior)" do
+    params = { "datetime_string" => "2016-04-01T16:00:00.000+09:00" }
+
+    check_parameter = lambda { |env|
+      assert_equal DateTime, env['committee.params']["datetime_string"].class
+      [200, {}, []]
+    }
+
+    @app = new_rack_app_with_lambda(check_parameter, schema: open_api_3_schema, coerce_date_times: true)
+
+    get "/get_body_test", { no_problem: true }, { input: params.to_json }
+    assert_equal 200, last_response.status
+  end
+
   it "passes given a datetime and with coerce_date_times enabled on POST endpoint" do
     params = {
         "nested_array" => [


### PR DESCRIPTION
When the user send parameter in requset body, committee with Hyper-Schema use it as requset parameter.
Because RequestUnpacker is parsed request body on all HTTP method.
https://github.com/interagent/committee/blob/master/lib/committee/request_unpacker.rb#L17

But when we use OpenAPI 3, we check request parameter only so we get error when required paramater in request body.
[OpenAPI 3 definition are not allowed request body](https://swagger.io/docs/specification/describing-request-body/) and request body isn't request parameter so it's correct behaviour.

```
GET, DELETE and HEAD are no longer allowed to have request body 
because it does not have defined semantics as per RFC 7231.
```

But in the committee, I think we should merge to request parameter for validation.
(This means OpenAPI 3 check requset parameter and request body like Hyper-Schema)

Because if we changee this behaviour, we should fix all client application when upgroade Hyper-Schema or OpenAPI 2 to OpenAPI3.
Sometimes the client application isn't under their control for example when APIs are published to internet so it's change isn't good.

In [RFC 7231](https://tools.ietf.org/html/rfc7231#section-4.3), there is no defined semantics.
So I think this behavior is bad but not very wrong.
```
   A payload within a GET request message has no defined semantics;
   sending a payload body on a GET request might cause some existing
   implementations to reject the request.
```

Now OpenAPI 3 validate and coerce merged parameter and bodies.
But when we coerce value, we check again with parameters only so we get error if the parameter in request body.
So I fix it to copy coerced value from merged data.