### PR TITLE
Allow GET request body data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 Unreleased
-
+	Allow GET request body data (#211)
 
 3.0.0.beta3 2019-01-25
 	OpenAPI 3 merge request body to request parameter in GET request (#210)

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ Options and their defaults:
 | name | Hyper-Schema | OpenAPI 3 | Description |
 |-----------:|------------:|------------:| :------------ |
 |allow_form_params | true | true | Specifies that input can alternatively be specified as `application/x-www-form-urlencoded` parameters when possible. This won't work for more complex schema validations. |
-|allow_query_params | true | true | Specifies that query string parameters will be taken into consideration when doing validation. |
 |allow_get_body | true | false | Allow GET request body, which merge to request parameter. See (#211) |
-|coerce_date_times | false | true | Convert the string with `"format": "date-time"` parameter to DateTime object. |
-|coerce_form_params| false | true | Tries to convert POST data encoded into an `application/x-www-form-urlencoded` body (where values are all strings) into concrete types required by the schema. This works for `null` (empty value), `integer` (numeric value without decimals), `number` (numeric value) and `boolean` ("true" is converted to `true` and "false" to `false`). If coercion is not possible, the original value is passed unchanged to schema validation. |
-|coerce_query_params| false | true  | The same as `coerce_form_params`, but tries to coerce `GET` parameters encoded in a request's query string. |
-|coerce_path_params| false | true | The same as `coerce_form_params`, but tries to coerce parameters encoded in a request's URL path. |
-|coerce_recursive| false | always true | Coerce data in arrays and other nested objects |
+|allow_query_params | true | true | Specifies that query string parameters will be taken into consideration when doing validation. |
 |check_content_type | true | true | Specifies that `Content-Type` should be verified according to JSON Hyper-schema or OpenAPI 3 definition. |
 |check_header | true | true | Check header data using JSON Hyper-schema or OpenAPI 3 definition. |
+|coerce_date_times | false | true | Convert the string with `"format": "date-time"` parameter to DateTime object. |
+|coerce_form_params| false | true | Tries to convert POST data encoded into an `application/x-www-form-urlencoded` body (where values are all strings) into concrete types required by the schema. This works for `null` (empty value), `integer` (numeric value without decimals), `number` (numeric value) and `boolean` ("true" is converted to `true` and "false" to `false`). If coercion is not possible, the original value is passed unchanged to schema validation. |
+|coerce_path_params| false | true | The same as `coerce_form_params`, but tries to coerce parameters encoded in a request's URL path. |
+|coerce_query_params| false | true  | The same as `coerce_form_params`, but tries to coerce `GET` parameters encoded in a request's query string. |
+|coerce_recursive| false | always true | Coerce data in arrays and other nested objects |
 |optimistic_json| false | false | Will attempt to parse JSON in the request body even without a `Content-Type: application/json` before falling back to other options. |
 |raise| false | false | Raise an exception on error instead of responding with a generic error body. |
 |strict| false | false | Puts the middleware into strict mode, meaning that paths which are not defined in the schema will be responded to with a 404 instead of being run. |
@@ -286,7 +286,6 @@ Committee 3.* has many breaking changes so we recommend upgrading to the latest 
 2. Run your test suite and fix any deprecation warnings that appear.
 3. Update to the latest 3.* release.
 4. Switch to OpenAPI 3 if you'd like to do so.
-   (If you use GET request body data, don't forget to set allow_get_body true.)
 
 Important changes are also described below.
 
@@ -356,6 +355,10 @@ end
 ```
 
 The default assertion option in 2.* was `validate_success_only=true`, but this becomes `validate_success_only=false` in 3.*. For the smoothest possible upgrade, you should set it to `false` in your test suite before upgrading to 3.*.
+
+### Other changes
+
+* `GET` request bodies are ignored in OpenAPI 3 by default. If you want to use them, set the `allow_get_body` option to `true`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Options and their defaults:
 |-----------:|------------:|------------:| :------------ |
 |allow_form_params | true | true | Specifies that input can alternatively be specified as `application/x-www-form-urlencoded` parameters when possible. This won't work for more complex schema validations. |
 |allow_query_params | true | true | Specifies that query string parameters will be taken into consideration when doing validation. |
+|allow_get_body | true | false | Allow GET request body, which merge to request parameter. See (#211) |
 |coerce_date_times | false | true | Convert the string with `"format": "date-time"` parameter to DateTime object. |
 |coerce_form_params| false | true | Tries to convert POST data encoded into an `application/x-www-form-urlencoded` body (where values are all strings) into concrete types required by the schema. This works for `null` (empty value), `integer` (numeric value without decimals), `number` (numeric value) and `boolean` ("true" is converted to `true` and "false" to `false`). If coercion is not possible, the original value is passed unchanged to schema validation. |
 |coerce_query_params| false | true  | The same as `coerce_form_params`, but tries to coerce `GET` parameters encoded in a request's query string. |
@@ -285,6 +286,7 @@ Committee 3.* has many breaking changes so we recommend upgrading to the latest 
 2. Run your test suite and fix any deprecation warnings that appear.
 3. Update to the latest 3.* release.
 4. Switch to OpenAPI 3 if you'd like to do so.
+   (If you use GET request body data, don't forget to set allow_get_body true.)
 
 Important changes are also described below.
 

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -68,6 +68,11 @@ module Committee
         raise "needs implementation"
       end
 
+      # Use GET request body to request parameter (request body merge to parameter)
+      def default_allow_get_body
+        raise "needs implementation"
+      end
+
       # Whether parameters in a request's path will be considered and coerced
       # by default.
       def default_path_params

--- a/lib/committee/drivers/hyper_schema.rb
+++ b/lib/committee/drivers/hyper_schema.rb
@@ -9,6 +9,10 @@ module Committee::Drivers
       false
     end
 
+    def default_allow_get_body
+      true
+    end
+
     # Whether parameters in a request's path will be considered and coerced by
     # default.
     def default_path_params

--- a/lib/committee/drivers/open_api_2.rb
+++ b/lib/committee/drivers/open_api_2.rb
@@ -9,6 +9,10 @@ module Committee::Drivers
       true
     end
 
+    def default_allow_get_body
+      true
+    end
+
     # Whether parameters in a request's path will be considered and coerced by
     # default.
     def default_path_params

--- a/lib/committee/drivers/open_api_3.rb
+++ b/lib/committee/drivers/open_api_3.rb
@@ -9,6 +9,10 @@ module Committee::Drivers
       true
     end
 
+    def default_allow_get_body
+      false
+    end
+
     # Whether parameters in a request's path will be considered and coerced by
     # default.
     def default_path_params

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -4,11 +4,11 @@ module Committee
       @request = request
 
       @allow_form_params  = options[:allow_form_params]
+      @allow_get_body     = options[:allow_get_body]
       @allow_query_params = options[:allow_query_params]
       @coerce_form_params = options[:coerce_form_params]
       @optimistic_json    = options[:optimistic_json]
       @schema_validator   = options[:schema_validator]
-      @allow_get_body     = options[:allow_get_body]
     end
 
     def call

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -8,6 +8,7 @@ module Committee
       @coerce_form_params = options[:coerce_form_params]
       @optimistic_json    = options[:optimistic_json]
       @schema_validator   = options[:schema_validator]
+      @allow_get_body     = options[:allow_get_body]
     end
 
     def call
@@ -70,20 +71,21 @@ module Committee
     end
 
     def parse_json
-      if (body = @request.body.read).length != 0
-        @request.body.rewind
-        hash = JSON.parse(body)
-        # We want a hash specifically. '42', 42, and [42] will all be
-        # decoded properly, but we can't use them here.
-        if !hash.is_a?(Hash)
-          raise BadRequest,
-            "Invalid JSON input. Require object with parameters as keys."
-        end
-        indifferent_params(hash)
+      return nil if @request.request_method == "GET" && !@allow_get_body
+
+      body = @request.body.read
       # if request body is empty, we just have empty params
-      else
-        nil
+      return nil if body.length == 0
+
+      @request.body.rewind
+      hash = JSON.parse(body)
+      # We want a hash specifically. '42', 42, and [42] will all be
+      # decoded properly, but we can't use them here.
+      if !hash.is_a?(Hash)
+        raise BadRequest,
+              "Invalid JSON input. Require object with parameters as keys."
       end
+      indifferent_params(hash)
     end
 
     def headers

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -66,10 +66,10 @@ class Committee::SchemaValidator
         request.env[validator_option.params_key], request.env[validator_option.headers_key] = Committee::RequestUnpacker.new(
             request,
             allow_form_params:  validator_option.allow_form_params,
+            allow_get_body:     validator_option.allow_get_body,
             allow_query_params: validator_option.allow_query_params,
             coerce_form_params: validator_option.coerce_form_params,
             optimistic_json:    validator_option.optimistic_json,
-            allow_get_body:     validator_option.allow_get_body,
             schema_validator:   self
         ).call
       end

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -69,6 +69,7 @@ class Committee::SchemaValidator
             allow_query_params: validator_option.allow_query_params,
             coerce_form_params: validator_option.coerce_form_params,
             optimistic_json:    validator_option.optimistic_json,
+            allow_get_body:     validator_option.allow_get_body,
             schema_validator:   self
         ).call
       end

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -68,6 +68,7 @@ class Committee::SchemaValidator
           allow_query_params: validator_option.allow_query_params,
           coerce_form_params: validator_option.coerce_form_params,
           optimistic_json:    validator_option.optimistic_json,
+          allow_get_body:     validator_option.allow_get_body,
           schema_validator:   self
       ).call
     end

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -65,10 +65,10 @@ class Committee::SchemaValidator
       request.env[validator_option.params_key], request.env[validator_option.headers_key] = Committee::RequestUnpacker.new(
           request,
           allow_form_params:  validator_option.allow_form_params,
+          allow_get_body:     validator_option.allow_get_body,
           allow_query_params: validator_option.allow_query_params,
           coerce_form_params: validator_option.coerce_form_params,
           optimistic_json:    validator_option.optimistic_json,
-          allow_get_body:     validator_option.allow_get_body,
           schema_validator:   self
       ).call
     end

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -1,37 +1,45 @@
 class Committee::SchemaValidator
   class Option
-    attr_reader :coerce_recursive, :params_key,
-                :allow_form_params, :allow_query_params,
+    # Boolean Options
+    attr_reader :allow_form_params,
+                :allow_get_body,
+                :allow_query_params,
+                :check_content_type,
+                :check_header,
+                :coerce_date_times,
+                :coerce_form_params,
+                :coerce_path_params,
+                :coerce_query_params,
+                :coerce_recursive,
                 :optimistic_json,
-                :coerce_form_params, :headers_key,
-                :coerce_query_params, :coerce_path_params,
-                :check_content_type, :check_header,
-                :coerce_date_times, :prefix,
-                :validate_success_only, :allow_get_body
+                :validate_success_only
+
+    # Non-boolean options:
+    attr_reader :headers_key,
+                :params_key,
+                :prefix
 
     def initialize(options, schema, schema_type)
+      # Non-boolean options
       @headers_key         = options[:headers_key] || "committee.headers"
       @params_key          = options[:params_key] || "committee.params"
-
       @prefix              = options[:prefix]
 
-      # response option
-      @validate_success_only = options.fetch(:validate_success_only, schema.driver.default_validate_success_only)
-
-      @coerce_recursive    = options.fetch(:coerce_recursive, true)
+      # Boolean options and have a common value by default
       @allow_form_params   = options.fetch(:allow_form_params, true)
       @allow_query_params  = options.fetch(:allow_query_params, true)
-      @optimistic_json     = options.fetch(:optimistic_json, false)
-
-      @coerce_form_params  = options.fetch(:coerce_form_params, schema.driver.default_coerce_form_params)
-      @coerce_date_times   = options.fetch(:coerce_date_times, schema.driver.default_coerce_date_times)
-      @coerce_query_params = options.fetch(:coerce_query_params, schema.driver.default_query_params)
-      @coerce_path_params  = options.fetch(:coerce_path_params, schema.driver.default_path_params)
-
       @check_content_type  = options.fetch(:check_content_type, true)
       @check_header        = options.fetch(:check_header, true)
+      @coerce_recursive    = options.fetch(:coerce_recursive, true)
+      @optimistic_json     = options.fetch(:optimistic_json, false)
 
+      # Boolean options and have a different value by default
       @allow_get_body      = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)
+      @coerce_date_times   = options.fetch(:coerce_date_times, schema.driver.default_coerce_date_times)
+      @coerce_form_params  = options.fetch(:coerce_form_params, schema.driver.default_coerce_form_params)
+      @coerce_path_params  = options.fetch(:coerce_path_params, schema.driver.default_path_params)
+      @coerce_query_params = options.fetch(:coerce_query_params, schema.driver.default_query_params)
+      @validate_success_only = options.fetch(:validate_success_only, schema.driver.default_validate_success_only)
     end
   end
 end

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -1,6 +1,13 @@
 class Committee::SchemaValidator
   class Option
-    attr_reader :coerce_recursive, :params_key, :allow_form_params, :allow_query_params, :optimistic_json, :coerce_form_params, :headers_key, :coerce_query_params, :coerce_path_params, :check_content_type, :check_header, :coerce_date_times, :prefix, :validate_success_only
+    attr_reader :coerce_recursive, :params_key,
+                :allow_form_params, :allow_query_params,
+                :optimistic_json,
+                :coerce_form_params, :headers_key,
+                :coerce_query_params, :coerce_path_params,
+                :check_content_type, :check_header,
+                :coerce_date_times, :prefix,
+                :validate_success_only, :allow_get_body
 
     def initialize(options, schema, schema_type)
       @headers_key         = options[:headers_key] || "committee.headers"
@@ -23,6 +30,8 @@ class Committee::SchemaValidator
 
       @check_content_type  = options.fetch(:check_content_type, true)
       @check_header        = options.fetch(:check_header, true)
+
+      @allow_get_body      = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)
     end
   end
 end

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -494,16 +494,15 @@ paths:
               description: integer
               schema:
                 type: integer
-  /get_body_test:
+  /get_endpoint_with_requered_parameter:
     get:
       description: get body test
       parameters:
-      - name: datetime_string
+      - name: data
         in: query
         required: true
         schema:
           type: string
-          format: date-time
       responses:
         '204':
           description: no content

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -93,10 +93,10 @@ end
 
 describe Committee::Drivers::Driver do
   DRIVER_METHODS = {
+    :default_allow_get_body     => [],
     :default_coerce_form_params => [],
     :default_path_params        => [],
     :default_query_params       => [],
-    :default_allow_get_body     => [],
     :name                       => [],
     :parse                      => [nil],
     :schema_class               => [],

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -96,6 +96,7 @@ describe Committee::Drivers::Driver do
     :default_coerce_form_params => [],
     :default_path_params        => [],
     :default_query_params       => [],
+    :default_allow_get_body     => [],
     :name                       => [],
     :parse                      => [nil],
     :schema_class               => [],

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -42,7 +42,25 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
-  it "passes given a datetime and with coerce_date_times enabled on GET endpoint with request body(old behavior)" do
+  it "passes given a valid parameter on GET endpoint with request body and allow_get_body=true" do
+    params = { "data" => "abc" }
+
+    @app = new_rack_app(schema: open_api_3_schema, allow_get_body: true)
+
+    get "/get_endpoint_with_requered_parameter", { no_problem: true }, { input: params.to_json }
+    assert_equal 200, last_response.status
+  end
+
+  it "get error given valid parameter on GET endpoint with request body and allow_get_body=false" do
+    params = { "data" => "abc" }
+
+    @app = new_rack_app(schema: open_api_3_schema, allow_get_body: false)
+
+    get "/get_endpoint_with_requered_parameter", { no_problem: true }, { input: params.to_json }
+    assert_equal 400, last_response.status
+  end
+
+  it "passes given a datetime and with coerce_date_times enabled on GET endpoint with request body" do
     params = { "datetime_string" => "2016-04-01T16:00:00.000+09:00" }
 
     check_parameter = lambda { |env|
@@ -55,17 +73,8 @@ describe Committee::Middleware::RequestValidation do
                                     coerce_date_times: true,
                                     allow_get_body: true)
 
-    get "/get_body_test", { no_problem: true }, { input: params.to_json }
+    get "/string_params_coercer", { no_problem: true }, { input: params.to_json }
     assert_equal 200, last_response.status
-  end
-
-  it "get error given a datetime and with coerce_date_times enabled on GET endpoint with request body" do
-    params = { "datetime_string" => "2016-04-01T16:00:00.000+09:00" }
-
-    @app = new_rack_app(schema: open_api_3_schema, allow_get_body: false)
-
-    get "/get_body_test", { no_problem: true }, { input: params.to_json }
-    assert_equal 400, last_response.status
   end
 
   it "passes given a datetime and with coerce_date_times enabled on POST endpoint" do

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -51,7 +51,7 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
-  it "get error given valid parameter on GET endpoint with request body and allow_get_body=false" do
+  it "errors given valid parameter on GET endpoint with request body and allow_get_body=false" do
     params = { "data" => "abc" }
 
     @app = new_rack_app(schema: open_api_3_schema, allow_get_body: false)

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -50,10 +50,22 @@ describe Committee::Middleware::RequestValidation do
       [200, {}, []]
     }
 
-    @app = new_rack_app_with_lambda(check_parameter, schema: open_api_3_schema, coerce_date_times: true)
+    @app = new_rack_app_with_lambda(check_parameter,
+                                    schema: open_api_3_schema,
+                                    coerce_date_times: true,
+                                    allow_get_body: true)
 
     get "/get_body_test", { no_problem: true }, { input: params.to_json }
     assert_equal 200, last_response.status
+  end
+
+  it "get error given a datetime and with coerce_date_times enabled on GET endpoint with request body" do
+    params = { "datetime_string" => "2016-04-01T16:00:00.000+09:00" }
+
+    @app = new_rack_app(schema: open_api_3_schema, allow_get_body: false)
+
+    get "/get_body_test", { no_problem: true }, { input: params.to_json }
+    assert_equal 400, last_response.status
   end
 
   it "passes given a datetime and with coerce_date_times enabled on POST endpoint" do

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -234,4 +234,26 @@ describe Committee::RequestUnpacker do
     _, headers = Committee::RequestUnpacker.new(request, { allow_header_params: true }).call
     assert_equal({ "FOO-BAR" => "some header value" }, headers)
   end
+
+  it "use_get_body = true" do
+    env = {
+        "rack.input" => StringIO.new('{"x":1, "y":2}'),
+        "REQUEST_METHOD" => "GET",
+        "QUERY_STRING"=>"data=value&x=aaa",
+    }
+    request = Rack::Request.new(env)
+    params, _ = Committee::RequestUnpacker.new(request, { allow_query_params: true, allow_get_body: true }).call
+    assert_equal({ 'data' => 'value', 'x' => 1, 'y' => 2 }, params)
+  end
+
+  it "use_get_body = false" do
+    env = {
+        "rack.input" => StringIO.new('{"x":1, "y":2}'),
+        "REQUEST_METHOD" => "GET",
+        "QUERY_STRING"=>"data=value&x=aaa",
+    }
+    request = Rack::Request.new(env)
+    params, _ = Committee::RequestUnpacker.new(request, { allow_query_params: true, use_get_body: false }).call
+    assert_equal({ 'data' => 'value', 'x' => 'aaa' }, params)
+  end
 end

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -235,7 +235,7 @@ describe Committee::RequestUnpacker do
     assert_equal({ "FOO-BAR" => "some header value" }, headers)
   end
 
-  it "use_get_body = true" do
+  it "includes request body when`use_get_body` is true" do
     env = {
         "rack.input" => StringIO.new('{"x":1, "y":2}'),
         "REQUEST_METHOD" => "GET",
@@ -246,7 +246,7 @@ describe Committee::RequestUnpacker do
     assert_equal({ 'data' => 'value', 'x' => 1, 'y' => 2 }, params)
   end
 
-  it "use_get_body = false" do
+  it "doesn't include request body when `use_get_body` is false" do
     env = {
         "rack.input" => StringIO.new('{"x":1, "y":2}'),
         "REQUEST_METHOD" => "GET",


### PR DESCRIPTION
We don't merge GET request body data to get parameter by default.
Because it's commitee original rule so it's difficult to understand.

close https://github.com/interagent/committee/issues/211