### PR TITLE
Update Sinatra examples compatible with version 3.0.0

### DIFF
--- a/examples/Gemfile.lock
+++ b/examples/Gemfile.lock
@@ -1,15 +1,17 @@
 PATH
   remote: ..
   specs:
-    committee (2.2.1)
+    committee (3.0.0)
       json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (>= 0.2.2)
       rack (>= 1.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    json_schema (0.19.1)
+    json_schema (0.20.1)
     mustermann (1.0.3)
+    openapi_parser (0.2.2)
     rack (2.0.5)
     rack-protection (2.0.4)
       rack
@@ -28,4 +30,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.16.3
+   1.17.2

--- a/examples/app.rb
+++ b/examples/app.rb
@@ -5,12 +5,12 @@ require "sinatra/base"
 require "yaml"
 
 class App < Sinatra::Base
-  SCHEMA = YAML.load(File.read(File.expand_path("../schema.json", __FILE__)))
+  SCHEMA_PATH = File.expand_path("../schema.json", __FILE__)
 
   # The request validator verifies that the required input parameters (and no
   # unknown input parameters) are included with the request and that they are
   # of the right types.
-  use Committee::Middleware::RequestValidation, schema: SCHEMA
+  use Committee::Middleware::RequestValidation, schema_path: SCHEMA_PATH
 
   # The stubbing middleware generates sample responses based on the schema. The
   # :call option indicates that it should still call down to the underlying
@@ -18,13 +18,13 @@ class App < Sinatra::Base
   #
   # Note that the stub's response can be modified or suppressed. See the POST
   # /apps and PATCH /apps/:id handlers below for examples.
-  use Committee::Middleware::Stub, call: true, schema: SCHEMA
+  use Committee::Middleware::Stub, schema_path: SCHEMA_PATH
 
   # The response validator checks that responses from within the stack are
   # compliant with the JSON schema. It's normally used for verification in
   # tests, but here we can use it to check that our changes to the stub's
   # responses are still compliant with our schema.
-  use Committee::Middleware::ResponseValidation, schema: SCHEMA
+  use Committee::Middleware::ResponseValidation, schema_path: SCHEMA_PATH
 
   # This handler is called into, but its response is ignored.
   get "/apps" do

--- a/examples/schema.json
+++ b/examples/schema.json
@@ -45,6 +45,16 @@
               "object"
             ]
           },
+          "targetSchema": {
+            "properties": {
+              "id": {
+                "$ref": "#/definitions/app/definitions/id"
+              },
+              "name": {
+                "$ref": "#/definitions/app/definitions/name"
+              }
+            }
+          },
           "title": "Create"
         },
         {
@@ -82,6 +92,16 @@
             "type": [
               "object"
             ]
+          },
+          "targetSchema": {
+            "properties": {
+              "id": {
+                "$ref": "#/definitions/app/definitions/id"
+              },
+              "name": {
+                "$ref": "#/definitions/app/definitions/name"
+              }
+            }
           },
           "title": "Update"
         }


### PR DESCRIPTION
When I try sinatra example at first time, two errors happen like below.

```
Traceback (most recent call last):
	13: from app.rb:59:in `<main>'

...

lib/committee/middleware/base.rb:36:in `get_schema': Committee: schema expected to be an instance of Committee::Drivers::Schema. (ArgumentError)
```

after fixing it

```
NoMethodError: undefined method `data' for nil:NilClass
	/Users/muratajunichi/Documents/Developments/committee/lib/committee/schema_validator/hyper_schema/response_generator.rb:39:in `generate_properties'
	/Users/muratajunichi/Documents/Developments/committee/lib/committee/schema_validator/hyper_schema/response_generator.rb:5:in `call'
...
```

so I fixed two errors.
I hope this patch help someone.