### PR TITLE
Correct `filepath` => `schema_path`

### DIFF
--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -27,7 +27,7 @@ module Committee::Middleware
         unless schema
           schema = Committee::Drivers::load_from_file(options[:schema_path]) if options[:schema_path]
 
-          raise(ArgumentError, "Committee: need option `schema` or `filepath`") unless schema
+          raise(ArgumentError, "Committee: need option `schema` or `schema_path`") unless schema
         end
 
         # Expect the type we want by now. If we don't have it, the user passed

--- a/test/middleware/base_test.rb
+++ b/test/middleware/base_test.rb
@@ -96,7 +96,7 @@ describe Committee::Middleware::Base do
       post "/apps"
     end
 
-    assert_equal "Committee: need option `schema` or `filepath`", e.message
+    assert_equal "Committee: need option `schema` or `schema_path`", e.message
   end
 
   describe 'initialize option' do
@@ -110,7 +110,7 @@ describe Committee::Middleware::Base do
       assert_kind_of Committee::Drivers::OpenAPI2::Schema, b.instance_variable_get(:@schema)
     end
 
-    it "filepath option with OpenAPI3" do
+    it "schema_path option with OpenAPI3" do
       b = Committee::Middleware::Base.new(nil, schema_path: open_api_3_schema_path)
       assert_kind_of Committee::Drivers::OpenAPI3::Schema, b.instance_variable_get(:@schema)
     end


### PR DESCRIPTION
The `filepath` option has been replaced to `schema_path`, but I faced to an old error message so I've fixed it. I also made same kind of fix in test files.