### PR TITLE
Support OpenAPI 3 patch version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Unreleased
 
+3.0.2 2019-05-15
+	Support OpenAPI 3 patch version (#223)
+
 3.0.1 2019-03-18
 	Correct use of `filepath` to `schema_path` (#216)
 

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = "committee"
-  s.version       = "3.0.1"
+  s.version       = "3.0.2"
 
   s.summary       = "A collection of Rack middleware to support JSON Schema."
 

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -47,7 +47,7 @@ module Committee
     # @param [Hash] hash
     # @return [Committee::Driver]
     def self.load_from_data(hash)
-      if hash['openapi'] == '3.0.0'
+      if hash['openapi']&.start_with?('3.0.')
         parser = OpenAPIParser.parse(hash)
         return Committee::Drivers::OpenAPI3.new.parse(parser)
       end

--- a/test/data/openapi3/3_0_1.yaml
+++ b/test/data/openapi3/3_0_1.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: OpenAPI3 Test
+  description: A Sample file
+paths:
+  /characters:
+    get:
+      description: get characters
+      parameters:
+      - name: school_name
+        in: query
+        description: school name to filter by
+        required: false
+        style: form
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -40,6 +40,12 @@ describe Committee::Drivers do
       assert_kind_of Committee::Drivers::OpenAPI3::Schema, s
     end
 
+    it 'load OpenAPI 3 (patch version 3.0.1)' do
+      s = Committee::Drivers.load_from_file(open_api_3_0_1_schema_path)
+      assert_kind_of Committee::Drivers::Schema, s
+      assert_kind_of Committee::Drivers::OpenAPI3::Schema, s
+    end
+
     it 'errors on an unsupported file extension' do
       e = assert_raises(StandardError) do
         Committee::Drivers.load_from_file('test.xml')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,3 +85,6 @@ def open_api_3_schema_path
   "./test/data/openapi3/normal.yaml"
 end
 
+def open_api_3_0_1_schema_path
+  "./test/data/openapi3/3_0_1.yaml"
+end


### PR DESCRIPTION
OpenAPI 3 have 3.0.1 and 3.0.2.
We shouldn't consider patch version.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#versions
```
The patch version SHOULD NOT be considered by tooling, making no 
distinction between 3.0.0 and 3.0.1 for example.
```

Thanks to @pekepek