### PR TITLE
Catch OpenAPIParser::NotExistRequiredKey with RequestValidation

### DIFF
--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -18,6 +18,8 @@ module Committee
       return {} unless options.coerce_value
 
       request_operation.validate_path_params(options)
+    rescue OpenAPIParser::NotExistRequiredKey => e
+      raise Committee::InvalidRequest.new(e.message)
     end
 
     # @param [Boolean] strict when not content_type or status code definition, raise error

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -312,6 +312,16 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 404, last_response.status
   end
 
+  it "OpenAPI3 parser not exist required key" do
+    @app = new_rack_app(raise: true, schema: open_api_3_schema)
+
+    e = assert_raises(Committee::InvalidRequest) do
+      get "/validate", nil
+    end
+
+    assert_match(/required parameters query_string not exist in/i, e.message)
+  end
+
   it "optionally raises an error" do
     @app = new_rack_app(raise: true, schema: open_api_3_schema)
     header "Content-Type", "application/json"


### PR DESCRIPTION
日本語で申し訳ありませんが、ご確認よろしくお願い致します🙇‍♂️

## Context

`Committee::ValidationError` を継承したクラスで、`OpenAPIParser::NotExistRequiredKey` 発生時にエラーをキャッチできない。
(request parameter に required key が不足している場合に発生する)