### PR TITLE
Fix typo: `the` duplicates

### DIFF
--- a/test/schema_validator/hyper_schema/response_generator_test.rb
+++ b/test/schema_validator/hyper_schema/response_generator_test.rb
@@ -43,7 +43,7 @@ describe Committee::SchemaValidator::HyperSchema::ResponseGenerator do
     data, _schema = call
 
     # We're testing for legacy behavior here: even without a `targetSchema` as
-    # long as `rel` is set to `instances` we still wrap the the result in an
+    # long as `rel` is set to `instances` we still wrap the result in an
     # array.
     assert_equal "instances", @list_link.rel
 

--- a/test/schema_validator/hyper_schema/response_validator_test.rb
+++ b/test/schema_validator/hyper_schema/response_validator_test.rb
@@ -43,7 +43,7 @@ describe Committee::SchemaValidator::HyperSchema::ResponseValidator do
     @link.target_schema = nil
 
     # We're testing for legacy behavior here: even without a `targetSchema` as
-    # long as `rel` is set to `instances` we still wrap the the result in an
+    # long as `rel` is set to `instances` we still wrap the result in an
     # array.
     assert_equal "instances", @link.rel
 
@@ -59,7 +59,7 @@ describe Committee::SchemaValidator::HyperSchema::ResponseValidator do
     @link.target_schema = nil
 
     # We're testing for legacy behavior here: even without a `targetSchema` as
-    # long as `rel` is set to `instances` we still wrap the the result in an
+    # long as `rel` is set to `instances` we still wrap the result in an
     # array.
     assert_equal "instances", @link.rel
 


### PR DESCRIPTION
This PR just fixes typos I found.