### PR TITLE
Support request validations by assert_schema_conform

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,20 @@ describe Committee::Middleware::Stub do
     it "conforms to schema" do
       assert_schema_conform
     end
-   end
+    
+    it "conforms to request schema" do
+      assert_request_schema_confirm
+    end
+    
+    it "conforms to response schema" do
+      assert_response_schema_confirm
+    end
+    
+    it "conforms to response and request schema" do
+      @committee_options[:old_assert_behavior] = false
+      assert_schema_conform
+    end
+  end
 end
 ```
 

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -1,18 +1,22 @@
 module Committee::Test
   module Methods
     def assert_schema_conform
-      @schema ||= Committee::Middleware::Base.get_schema(committee_options)
-      @router ||= @schema.build_router(committee_options)
+      assert_request_schema_confirm unless old_behavior
+      assert_response_schema_confirm
+    end
 
-      v = @router.build_schema_validator(request_object)
+    def assert_request_schema_confirm
+      schema_validator.request_validate(request_object)
+    end
 
-      unless v.link_exist?
+    def assert_response_schema_confirm
+      unless schema_validator.link_exist?
         response = "`#{request_object.request_method} #{request_object.path_info}` undefined in schema."
         raise Committee::InvalidResponse.new(response)
       end
 
       status, headers, body = response_data
-      v.response_validate(status, headers, [body], true) if validate_response?(status)
+      schema_validator.response_validate(status, headers, [body], true) if validate_response?(status)
     end
 
     def committee_options
@@ -29,6 +33,32 @@ module Committee::Test
 
     def validate_response?(status)
       Committee::Middleware::ResponseValidation.validate?(status, committee_options.fetch(:validate_success_only, false))
+    end
+
+    def schema
+      @schema ||= Committee::Middleware::Base.get_schema(committee_options)
+    end
+
+    def router
+      @router ||= schema.build_router(committee_options)
+    end
+
+    def schema_validator
+      @schema_validator ||= router.build_schema_validator(request_object)
+    end
+
+    def old_behavior
+      old_assert_behavior = committee_options.fetch(:old_assert_behavior, nil)
+      if old_assert_behavior.nil?
+        warn <<-MSG
+        [DEPRECATION] now assert_schema_confirm check response schema only.
+          but we will change check request and response in future major version.
+          so if you want to conform response only, please use assert_response_schema_confirm,
+          or you can suppress this message and keep old behavior by setting old_assert_behavior=true.
+        MSG
+        old_assert_behavior = true
+      end
+      old_assert_behavior
     end
   end
 end

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -6,6 +6,11 @@ module Committee::Test
     end
 
     def assert_request_schema_confirm
+      unless schema_validator.link_exist?
+        request = "`#{request_object.request_method} #{request_object.path_info}` undefined in schema."
+        raise Committee::InvalidRequest.new(request)
+      end
+
       schema_validator.request_validate(request_object)
     end
 

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -78,6 +78,15 @@ describe Committee::Test::Methods do
         end
         assert_match(/"query" wasn't supplied\./i, e.message)
       end
+
+      it "path undefined in schema" do
+        @app = new_rack_app([])
+        get "/undefined"
+        e = assert_raises(Committee::InvalidRequest) do
+          assert_request_schema_confirm
+        end
+        assert_match(/`GET \/undefined` undefined in schema/i, e.message)
+      end
     end
 
     describe "#assert_response_schema_confirm" do
@@ -94,6 +103,15 @@ describe Committee::Test::Methods do
           assert_response_schema_confirm
         end
         assert_match(/response header must be set to/i, e.message)
+      end
+
+      it "path undefined in schema" do
+        @app = new_rack_app(JSON.generate([ValidApp]))
+        get "/undefined"
+        e = assert_raises(Committee::InvalidResponse) do
+          assert_response_schema_confirm
+        end
+        assert_match(/`GET \/undefined` undefined in schema/i, e.message)
       end
     end
   end
@@ -157,6 +175,15 @@ describe Committee::Test::Methods do
         end
         assert_match(/required parameters query_string not exist in #\/paths/i, e.message)
       end
+
+      it "path undefined in schema" do
+        @app = new_rack_app([])
+        get "/undefined"
+        e = assert_raises(Committee::InvalidRequest) do
+          assert_request_schema_confirm
+        end
+        assert_match(/`GET \/undefined` undefined in schema/i, e.message)
+      end
     end
 
     describe "#assert_response_schema_confirm" do
@@ -184,6 +211,15 @@ describe Committee::Test::Methods do
           assert_response_schema_confirm
         end
         assert_match(/don't exist status code definition/i, e.message)
+      end
+
+      it "path undefined in schema" do
+        @app = new_rack_app(JSON.generate(@correct_response))
+        get "/undefined"
+        e = assert_raises(Committee::InvalidResponse) do
+          assert_response_schema_confirm
+        end
+        assert_match(/`GET \/undefined` undefined in schema/i, e.message)
       end
     end
   end

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -63,6 +63,23 @@ describe Committee::Test::Methods do
       end
     end
 
+    describe "assert_request_schema_confirm" do
+      it "passes through a valid request" do
+        @app = new_rack_app([])
+        get "/apps"
+        assert_request_schema_confirm
+      end
+
+      it "not exist required" do
+        @app = new_rack_app([])
+        get "/search/apps", {}
+        e = assert_raises(Committee::InvalidRequest) do
+          assert_request_schema_confirm
+        end
+        assert_match(/"query" wasn't supplied\./i, e.message)
+      end
+    end
+
     describe "#assert_response_schema_confirm" do
       it "passes through a valid response" do
         @app = new_rack_app(JSON.generate([ValidApp]))
@@ -122,6 +139,23 @@ describe Committee::Test::Methods do
           assert_schema_conform
         end
         assert_match(/\[DEPRECATION\]/i, err)
+      end
+    end
+
+    describe "assert_request_schema_confirm" do
+      it "passes through a valid request" do
+        @app = new_rack_app([])
+        get "/characters"
+        assert_request_schema_confirm
+      end
+
+      it "not exist required" do
+        @app = new_rack_app([])
+        get "/validate", {"query_string" => "query", "query_integer_list" => [1, 2]}
+        e = assert_raises(Committee::InvalidRequest) do
+          assert_request_schema_confirm
+        end
+        assert_match(/required parameters query_string not exist in #\/paths/i, e.message)
       end
     end
 

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -62,6 +62,23 @@ describe Committee::Test::Methods do
         assert_match(/\[DEPRECATION\]/i, err)
       end
     end
+
+    describe "#assert_response_schema_confirm" do
+      it "passes through a valid response" do
+        @app = new_rack_app(JSON.generate([ValidApp]))
+        get "/apps"
+        assert_response_schema_confirm
+      end
+
+      it "detects an invalid response Content-Type" do
+        @app = new_rack_app(JSON.generate([ValidApp]), {})
+        get "/apps"
+        e = assert_raises(Committee::InvalidResponse) do
+          assert_response_schema_confirm
+        end
+        assert_match(/response header must be set to/i, e.message)
+      end
+    end
   end
 
   describe "OpenAPI3" do
@@ -105,6 +122,34 @@ describe Committee::Test::Methods do
           assert_schema_conform
         end
         assert_match(/\[DEPRECATION\]/i, err)
+      end
+    end
+
+    describe "#assert_response_schema_confirm" do
+      it "passes through a valid response" do
+        @app = new_rack_app(JSON.generate(@correct_response))
+        get "/characters"
+        assert_response_schema_confirm
+      end
+
+      it "detects an invalid response Content-Type" do
+        @app = new_rack_app(JSON.generate([@correct_response]), {})
+        get "/characters"
+        e = assert_raises(Committee::InvalidResponse) do
+          assert_response_schema_confirm
+        end
+        assert_match(/don't exist response definition/i, e.message)
+      end
+
+      it "detects an invalid response status code" do
+        @app = new_rack_app(JSON.generate([@correct_response]), {}, 419)
+
+        get "/characters"
+
+        e = assert_raises(Committee::InvalidResponse) do
+          assert_response_schema_confirm
+        end
+        assert_match(/don't exist status code definition/i, e.message)
       end
     end
   end

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -52,6 +52,15 @@ describe Committee::Test::Methods do
         end
         assert_match(/response header must be set to/i, e.message)
       end
+
+      it "outputs deprecation warning" do
+        @app = new_rack_app(JSON.generate([ValidApp]))
+        get "/apps"
+        _, err = capture_io do
+          assert_schema_conform
+        end
+        assert_match(/\[DEPRECATION\]/i, err)
+      end
     end
   end
 
@@ -87,6 +96,15 @@ describe Committee::Test::Methods do
           assert_schema_conform
         end
         assert_match(/don't exist status code definition/i, e.message)
+      end
+
+      it "outputs deprecation warning" do
+        @app = new_rack_app(JSON.generate(@correct_response))
+        get "/characters"
+        _, err = capture_io do
+          assert_schema_conform
+        end
+        assert_match(/\[DEPRECATION\]/i, err)
       end
     end
   end


### PR DESCRIPTION
## Issue

With assert_schema_conform, you can only confirm the response.

## This PR

I can't find request check, so I added it.

## Example

Can performa request validation.

```
assert_schema_conform(request_validation: true, response_validation: false)
```