### PR TITLE
fix: ensure we catch all OpenAPIParser::OpenAPIError classes when coercing path parameters for OpenAPI 3

### DIFF
--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -18,7 +18,7 @@ module Committee
       return {} unless options.coerce_value
 
       request_operation.validate_path_params(options)
-    rescue OpenAPIParser::NotExistRequiredKey => e
+    rescue OpenAPIParser::OpenAPIError => e
       raise Committee::InvalidRequest.new(e.message)
     end
 

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -322,6 +322,17 @@ describe Committee::Middleware::RequestValidation do
     assert_match(/required parameters query_string not exist in/i, e.message)
   end
 
+  it "raises error when required path parameter is invalid" do
+    @app = new_rack_app(raise: true, schema: open_api_3_schema)
+
+    e = assert_raises(Committee::InvalidRequest) do
+      not_an_integer = 'abc'
+      get "/coerce_path_params/#{not_an_integer}", nil
+    end
+
+    assert_match(/is String but it's not valid integer in/i, e.message)
+  end
+
   it "optionally raises an error" do
     @app = new_rack_app(raise: true, schema: open_api_3_schema)
     header "Content-Type", "application/json"


### PR DESCRIPTION
#### bug summary

I found that when we send a request with path
```
/resource/{id}/...
```
 
while a missing ID will be wrapped into a `Committee::InvalidRequest error`, an existing but invalid ID will still be uncaught; This gets bubbled up as an `OpenAPIParser::ValidateError` instead.

I think for consistency, we can catch all `OpenAPIParser::OpenAPIError` in the rescue operation.

Related PR: https://github.com/interagent/committee/pull/225