### PR TITLE
Add error handler option to Committee::Middleware::RequestValidation

### DIFF
--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -4,6 +4,7 @@ module Committee::Middleware
       @app = app
 
       @error_class = options.fetch(:error_class, Committee::ValidationError)
+      @error_handler = options[:error_handler]
 
       @raise = options[:raise]
       @schema = self.class.get_schema(options)

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -17,6 +17,7 @@ module Committee::Middleware
 
       @app.call(request.env)
     rescue Committee::BadRequest, Committee::InvalidRequest
+      @error_handler.call($!) if @error_handler
       raise if @raise
       @error_class.new(400, :bad_request, $!.message).render
     rescue Committee::NotFound => e
@@ -27,6 +28,7 @@ module Committee::Middleware
         e.message
       ).render
     rescue JSON::ParserError
+      @error_handler.call($!) if @error_handler
       raise Committee::InvalidRequest if @raise
       @error_class.new(400, :bad_request, "Request body wasn't valid JSON.").render
     end

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -5,8 +5,6 @@ module Committee::Middleware
     def initialize(app, options = {})
       super
       @validate_success_only = @schema.validator_option.validate_success_only
-
-      @error_handler = options[:error_handler]
     end
 
     def handle(request)


### PR DESCRIPTION
Added error_handler option to `Committee::Middleware::RequestValidation`

### Use case

When request is invalid, I want to send an exception event to Sentry. But currently it cound not do that. So I've opened this pull request.