### PR TITLE
Configure rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ AllCops:
     - 'examples/**/*'
     - 'vendor/**/*'
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
 Style/HashSyntax:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ Style/FrozenStringLiteralComment:
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
 Style/HashSyntax:
   Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Style/HashSyntax:
 
 Performance/RedundantMerge:
   Enabled: true
+
+Performance/UnfreezeString:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.3
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
@@ -6,6 +9,10 @@ AllCops:
   Exclude:
     - 'examples/**/*'
     - 'vendor/**/*'
+
+Performance:
+  Exclude:
+    - 'test/**/*'
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+AllCops:
+  TargetRubyVersion: 2.3
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+  Exclude:
+    - 'examples/**/*'
+    - 'vendor/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ AllCops:
   Exclude:
     - 'examples/**/*'
     - 'vendor/**/*'
+
+# Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
+Style/HashSyntax:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 require 'rake/testtask'
 require 'rubocop/rake_task'

--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,4 @@ end
 
 RuboCop::RakeTask.new
 
-task :default => [:rubocop, :test]
+task default: [:rubocop, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler'
 require 'rake/testtask'
+require 'rubocop/rake_task'
 
 Bundler::GemHelper.install_tasks
 
@@ -9,4 +10,6 @@ Rake::TestTask.new do |t|
   t.verbose = true
 end
 
-task :default => :test
+RuboCop::RakeTask.new
+
+task :default => [:rubocop, :test]

--- a/bin/committee-stub
+++ b/bin/committee-stub
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'optparse'
 require 'yaml'

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name          = "committee"
   s.version       = "3.1.0"

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop-performance"
   s.add_development_dependency "simplecov"
 end

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rr", "~> 1.1"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"
+  s.add_development_dependency "rubocop"
   s.add_development_dependency "simplecov"
 end

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "json"
 require "yaml"
 require "json_schema"

--- a/lib/committee/bin/committee_stub.rb
+++ b/lib/committee/bin/committee_stub.rb
@@ -29,10 +29,10 @@ module Committee
       # Gets an option parser for command line arguments.
       def get_options_parser
         options = {
-          :driver   => nil,
-          :help     => false,
-          :port     => 9292,
-          :tolerant => false,
+          driver: nil,
+          help: false,
+          port: 9292,
+          tolerant: false,
         }
 
         parser = OptionParser.new do |opts|

--- a/lib/committee/bin/committee_stub.rb
+++ b/lib/committee/bin/committee_stub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Don't Support OpenAPI3
 
 module Committee

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   module Drivers
     # Gets a driver instance from the specified name. Raises ArgumentError for

--- a/lib/committee/drivers/hyper_schema.rb
+++ b/lib/committee/drivers/hyper_schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee::Drivers
   class HyperSchema < Committee::Drivers::Driver
     def default_coerce_date_times

--- a/lib/committee/drivers/open_api_2.rb
+++ b/lib/committee/drivers/open_api_2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee::Drivers
   class OpenAPI2 < Committee::Drivers::Driver
     def default_coerce_date_times

--- a/lib/committee/drivers/open_api_2.rb
+++ b/lib/committee/drivers/open_api_2.rb
@@ -399,7 +399,7 @@ module Committee::Drivers
     def rewrite_references_and_parse(schemas_data, store)
       schemas = rewrite_references(schemas_data)
       schemas = JsonSchema.parse!(schemas_data)
-      schemas.expand_references!(:store => store)
+      schemas.expand_references!(store: store)
       schemas
     end
 

--- a/lib/committee/drivers/open_api_3.rb
+++ b/lib/committee/drivers/open_api_3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee::Drivers
   class OpenAPI3 < Committee::Drivers::Driver
     def default_coerce_date_times

--- a/lib/committee/errors.rb
+++ b/lib/committee/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class Error < StandardError
   end

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee::Middleware
   class Base
     def initialize(app, options={})

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee::Middleware
   class RequestValidation < Base
     def initialize(app, options={})

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee::Middleware
   class ResponseValidation < Base
     attr_reader :validate_success_only

--- a/lib/committee/middleware/stub.rb
+++ b/lib/committee/middleware/stub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Stub is not yet supported in OpenAPI 3
 
 module Committee::Middleware

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -98,7 +98,7 @@ module Committee
         headers
       end
 
-      base.merge!('Content-Type' => env['CONTENT_TYPE']) if env['CONTENT_TYPE']
+      base['Content-Type'] = env['CONTENT_TYPE'] if env['CONTENT_TYPE']
       base
     end
   end

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class RequestUnpacker
     def initialize(request, options={})

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -30,7 +30,7 @@ class Committee::SchemaValidator
     def response_validate(status, headers, response, _test_method = false)
       return unless link_exist?
 
-      full_body = "".dup
+      full_body = +""
       response.each do |chunk|
         full_body << chunk
       end

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Committee::SchemaValidator
   class HyperSchema
     attr_reader :link, :param_matches, :validator_option
@@ -28,7 +30,7 @@ class Committee::SchemaValidator
     def response_validate(status, headers, response, _test_method = false)
       return unless link_exist?
 
-      full_body = ""
+      full_body = "".dup
       response.each do |chunk|
         full_body << chunk
       end

--- a/lib/committee/schema_validator/hyper_schema/parameter_coercer.rb
+++ b/lib/committee/schema_validator/hyper_schema/parameter_coercer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::HyperSchema::ParameterCoercer
     def initialize(params, schema, options = {})

--- a/lib/committee/schema_validator/hyper_schema/request_validator.rb
+++ b/lib/committee/schema_validator/hyper_schema/request_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::HyperSchema::RequestValidator
     def initialize(link, options = {})

--- a/lib/committee/schema_validator/hyper_schema/response_generator.rb
+++ b/lib/committee/schema_validator/hyper_schema/response_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::HyperSchema::ResponseGenerator
     def call(link)

--- a/lib/committee/schema_validator/hyper_schema/response_validator.rb
+++ b/lib/committee/schema_validator/hyper_schema/response_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::HyperSchema::ResponseValidator
     attr_reader :validate_success_only

--- a/lib/committee/schema_validator/hyper_schema/router.rb
+++ b/lib/committee/schema_validator/hyper_schema/router.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::HyperSchema::Router
     def initialize(schema, validator_option)

--- a/lib/committee/schema_validator/hyper_schema/string_params_coercer.rb
+++ b/lib/committee/schema_validator/hyper_schema/string_params_coercer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   # StringParamsCoercer takes parameters that are specified over a medium that
   # can only accept strings (for example in a URL path or in query parameters)

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Committee::SchemaValidator
   class OpenAPI3
     # @param [Committee::SchemaValidator::Option] validator_option
@@ -21,7 +23,7 @@ class Committee::SchemaValidator
     end
 
     def response_validate(status, headers, response, test_method = false)
-      full_body = ""
+      full_body = "".dup
       response.each do |chunk|
         full_body << chunk
       end

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -23,7 +23,7 @@ class Committee::SchemaValidator
     end
 
     def response_validate(status, headers, response, test_method = false)
-      full_body = "".dup
+      full_body = +""
       response.each do |chunk|
         full_body << chunk
       end

--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::OpenAPI3::OperationWrapper
     # # @param request_operation [OpenAPIParser::RequestOperation]

--- a/lib/committee/schema_validator/open_api_3/request_validator.rb
+++ b/lib/committee/schema_validator/open_api_3/request_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::OpenAPI3::RequestValidator
     # @param [SchemaValidator::OpenAPI3::OperationWrapper] operation_object

--- a/lib/committee/schema_validator/open_api_3/response_validator.rb
+++ b/lib/committee/schema_validator/open_api_3/response_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::OpenAPI3::ResponseValidator
     attr_reader :validate_success_only

--- a/lib/committee/schema_validator/open_api_3/router.rb
+++ b/lib/committee/schema_validator/open_api_3/router.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class SchemaValidator::OpenAPI3::Router
     # @param [Committee::SchemaValidator::Option] validator_option

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Committee::SchemaValidator
   class Option
     # Boolean Options

--- a/lib/committee/schema_validator/schema_validator.rb
+++ b/lib/committee/schema_validator/schema_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Committee::SchemaValidator
   class << self
     def request_media_type(request)

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee::Test
   module Methods
     def assert_schema_conform

--- a/lib/committee/validation_error.rb
+++ b/lib/committee/validation_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Committee
   class ValidationError
     attr_reader :id, :message, :status

--- a/test/bin/committee_stub_test.rb
+++ b/test/bin/committee_stub_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Bin::CommitteeStub do

--- a/test/bin_test.rb
+++ b/test/bin_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 #

--- a/test/committee_test.rb
+++ b/test/committee_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 describe Committee do

--- a/test/drivers/hyper_schema_test.rb
+++ b/test/drivers/hyper_schema_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Drivers::HyperSchema do

--- a/test/drivers/open_api_2_test.rb
+++ b/test/drivers/open_api_2_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Drivers::OpenAPI2 do

--- a/test/drivers/open_api_3_test.rb
+++ b/test/drivers/open_api_3_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Drivers::OpenAPI3 do

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -99,13 +99,13 @@ end
 
 describe Committee::Drivers::Driver do
   DRIVER_METHODS = {
-    :default_allow_get_body     => [],
-    :default_coerce_form_params => [],
-    :default_path_params        => [],
-    :default_query_params       => [],
-    :name                       => [],
-    :parse                      => [nil],
-    :schema_class               => [],
+    default_allow_get_body: [],
+    default_coerce_form_params: [],
+    default_path_params: [],
+    default_query_params: [],
+    name: [],
+    parse: [nil],
+    schema_class: [],
   }
 
   it "has a set of abstract methods" do
@@ -122,8 +122,8 @@ end
 
 describe Committee::Drivers::Schema do
   SCHEMA_METHODS = {
-    :driver => [],
-    :build_router => [validator_option: nil, prefix: nil]
+    driver: [],
+    build_router: [validator_option: nil, prefix: nil]
   }
 
   it "has a set of abstract methods" do

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 describe Committee::Drivers do

--- a/test/middleware/base_test.rb
+++ b/test/middleware/base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Middleware::Base do

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Middleware::RequestValidation do

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Middleware::RequestValidation do

--- a/test/middleware/response_validation_open_api_3_test.rb
+++ b/test/middleware/response_validation_open_api_3_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Middleware::ResponseValidation do

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Middleware::ResponseValidation do

--- a/test/middleware/stub_test.rb
+++ b/test/middleware/stub_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Middleware::Stub do

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 require "stringio"

--- a/test/schema_validator/hyper_schema/parameter_coercer_test.rb
+++ b/test/schema_validator/hyper_schema/parameter_coercer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 require "stringio"

--- a/test/schema_validator/hyper_schema/request_validator_test.rb
+++ b/test/schema_validator/hyper_schema/request_validator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 require "stringio"

--- a/test/schema_validator/hyper_schema/response_generator_test.rb
+++ b/test/schema_validator/hyper_schema/response_generator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 describe Committee::SchemaValidator::HyperSchema::ResponseGenerator do

--- a/test/schema_validator/hyper_schema/response_validator_test.rb
+++ b/test/schema_validator/hyper_schema/response_validator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 describe Committee::SchemaValidator::HyperSchema::ResponseValidator do

--- a/test/schema_validator/hyper_schema/router_test.rb
+++ b/test/schema_validator/hyper_schema/router_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 describe Committee::SchemaValidator::HyperSchema::Router do

--- a/test/schema_validator/hyper_schema/string_params_coercer_test.rb
+++ b/test/schema_validator/hyper_schema/string_params_coercer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 describe Committee::SchemaValidator::HyperSchema::StringParamsCoercer do

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 require "stringio"

--- a/test/schema_validator/open_api_3/request_validator_test.rb
+++ b/test/schema_validator/open_api_3/request_validator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 describe Committee::SchemaValidator::OpenAPI3::RequestValidator do

--- a/test/schema_validator/open_api_3/response_validator_test.rb
+++ b/test/schema_validator/open_api_3/response_validator_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../../test_helper"
 
 describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do

--- a/test/test/methods_new_version_test.rb
+++ b/test/test/methods_new_version_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Test::Methods do

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../test_helper"
 
 describe Committee::Test::Methods do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if RUBY_VERSION >= '2.0.0'
   require 'simplecov'
 

--- a/test/validation_error_test.rb
+++ b/test/validation_error_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "test_helper"
 
 describe Committee::ValidationError do


### PR DESCRIPTION
We have to keep our codes clean minimally. So Enabled rubocop in committee gem.

## Summary

- Add rubocop, rubocop-performance to dev dependencies.
- But its configuration is `DisabledByDefault: false`.
- Run rubocop task with default rake task.
- Enable Style/HashSyntax (avoid 🚀 hash)
- Enable Style/FrozenStringLiteralComment (for performance)
- Enable Performance/RedundantMerge cop (for performance)
- Enable Performance/UnfreezeString cop (for performance)