### PR TITLE
OS3 request validator skip if link does not exist

### DIFF
--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -12,6 +12,8 @@ module Committee
       end
 
       def request_validate(request)
+        return unless link_exist?
+
         path_params = validator_option.coerce_path_params ? coerce_path_params : {}
 
         request_unpack(request)
@@ -49,7 +51,6 @@ module Committee
       attr_reader :validator_option
 
       def coerce_path_params
-        return {} unless link_exist?
         @operation_object.coerce_path_parameter(@validator_option)
       end
 

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -256,7 +256,7 @@ describe Committee::Middleware::RequestValidation do
   it "rescues JSON errors" do
     @app = new_rack_app(schema: open_api_3_schema)
     header "Content-Type", "application/json"
-    post "/apps", "{x:y}"
+    post "/characters", "{x:y}"
     assert_equal 400, last_response.status
     assert_match(/valid json/i, last_response.body)
   end

--- a/test/schema_validator/open_api_3/request_validator_test.rb
+++ b/test/schema_validator/open_api_3/request_validator_test.rb
@@ -10,6 +10,14 @@ describe Committee::SchemaValidator::OpenAPI3::RequestValidator do
       @app
     end
 
+    it "skip validaiton when link does not exist" do
+      @app = new_rack_app(schema: open_api_3_schema)
+      params = {}
+      header "Content-Type", "application/json"
+      post "/unknown", JSON.generate(params)
+      assert_equal 200, last_response.status
+    end
+
     it "optionally content_type check" do
       @app = new_rack_app(check_content_type: true, schema: open_api_3_schema)
       params = {


### PR DESCRIPTION
## Summary

- When link does not exist in schema.json, it seems that request object coerced change with unpack.
- It looks it's not intentional behavior, so I've added guard clause  which checks link exists or not before validation.
