### PR TITLE
OpenAPI 3: Improve an error message of request content type validation

### DIFF
--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -64,6 +64,10 @@ module Committee
           end
         end
 
+        def request_content_types
+          request_operation.operation_object&.request_body&.content&.keys || []
+        end
+
         private
 
         attr_reader :request_operation

--- a/lib/committee/schema_validator/open_api_3/request_validator.rb
+++ b/lib/committee/schema_validator/open_api_3/request_validator.rb
@@ -25,7 +25,17 @@ module Committee
           return true unless request.post? || request.put? || request.patch?
           return true if @operation_object.valid_request_content_type?(content_type)
 
-          raise Committee::InvalidRequest, %{"Content-Type" request header must be set to "#{@operation_object}".}
+          message = if valid_content_types.size > 1
+                      types = valid_content_types.map {|x| %{"#{x}"} }.join(', ')
+                      %{"Content-Type" request header must be set to any of the following: [#{types}].}
+                    else
+                      %{"Content-Type" request header must be set to "#{valid_content_types.first}".}
+                    end
+          raise Committee::InvalidRequest, message
+        end
+
+        def valid_content_types
+          @operation_object&.request_content_types
         end
       end
     end

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -355,6 +355,26 @@ paths:
                   string:
                     type: string
 
+  /validate_content_types:
+    post:
+      description: validate request content type
+      responses:
+        '200':
+          description: correct
+          content:
+            application/json:
+              schema:
+                type: object
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+          application/binary:
+            schema:
+              type: string
+              format: binary
+
   /validate_no_parameter:
     patch:
       description: validate no body

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -146,5 +146,21 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
         assert e.message.start_with?("a class is String but")
       end
     end
+
+    describe '#content_types' do
+      it 'returns supported content types' do
+        @path = '/validate_content_types'
+        @method = 'post'
+
+        assert_equal ["application/json", "application/binary"], operation_object.request_content_types
+      end
+
+      it 'returns an empty array when the content of requestBody does not exist' do
+        @path = '/characters'
+        @method = 'get'
+
+        assert_equal [], operation_object.request_content_types
+      end
+    end
   end
 end

--- a/test/schema_validator/open_api_3/request_validator_test.rb
+++ b/test/schema_validator/open_api_3/request_validator_test.rb
@@ -21,11 +21,34 @@ describe Committee::SchemaValidator::OpenAPI3::RequestValidator do
     it "optionally content_type check" do
       @app = new_rack_app(check_content_type: true, schema: open_api_3_schema)
       params = {
-          "string_post_1" => "cloudnasium"
+        "string_post_1" => "cloudnasium"
       }
       header "Content-Type", "text/html"
       post "/characters", JSON.generate(params)
       assert_equal 400, last_response.status
+
+      body = JSON.parse(last_response.body)
+      message =
+          %{"Content-Type" request header must be set to "application/json".}
+
+      assert_equal "bad_request", body['id']
+      assert_equal message, body['message']
+    end
+
+    it "validates content_type" do
+      @app = new_rack_app(check_content_type: true, schema: open_api_3_schema)
+      params = {
+        "string_post_1" => "cloudnasium"
+      }
+      header "Content-Type", "text/html"
+      post "/validate_content_types", JSON.generate(params)
+      assert_equal 400, last_response.status
+
+      body = JSON.parse(last_response.body)
+      message =
+        %{"Content-Type" request header must be set to any of the following: ["application/json", "application/binary"].}
+
+      assert_equal message, body['message']
     end
 
     it "optionally skip content_type check" do

--- a/test/schema_validator/open_api_3/request_validator_test.rb
+++ b/test/schema_validator/open_api_3/request_validator_test.rb
@@ -10,7 +10,7 @@ describe Committee::SchemaValidator::OpenAPI3::RequestValidator do
       @app
     end
 
-    it "skip validaiton when link does not exist" do
+    it "skip validation when link does not exist" do
       @app = new_rack_app(schema: open_api_3_schema)
       params = {}
       header "Content-Type", "application/json"
@@ -38,7 +38,7 @@ describe Committee::SchemaValidator::OpenAPI3::RequestValidator do
       assert_equal 200, last_response.status
     end
 
-    it "if not exist requsetBody definition, skip content_type check" do
+    it "if not exist requestBody definition, skip content_type check" do
       @app = new_rack_app(check_content_type: true, schema: open_api_3_schema)
       params = {
           "string_post_1" => "cloudnasium"


### PR DESCRIPTION
When the request content type is invalid, we get the following error

```json
{
  "id": "bad_request",
  "message": "\"Content-Type\" request header must be set to \"#<Committee::SchemaValidator::OpenAPI3::OperationWrapper:0xXXXXXX>\"."
}
```

This patch improves it to

```json
{
  "id": "bad_request",
  "message": "\"Content-Type\" request header must be set to \"application/json\"."
}
```

or following if the content has two or more keys

```json
{
  "id": "bad_request",
  "message": "\"Content-Type\" request header must be set to any of the following: [\"application/json\", \"application/binary\"]."
}
```