### PR TITLE
Remove unnecessary comment

### DIFF
--- a/lib/committee/schema_validator/open_api_3/response_validator.rb
+++ b/lib/committee/schema_validator/open_api_3/response_validator.rb
@@ -17,7 +17,6 @@ module Committee
         def call(status, headers, response_data, strict)
           return unless Committee::Middleware::ResponseValidation.validate?(status, validate_success_only)
 
-          #content_type = headers['Content-Type'].to_s.split(";").first.to_s
           operation_wrapper.validate_response_params(status, headers, response_data, strict, check_header)
         end
 


### PR DESCRIPTION
This pull request is a minor patch to remove a line which is commented out since https://github.com/interagent/committee/commit/94ae1f923993d3d03aa3cf17ecffa7cf89752933#diff-ba767ce3007de88371fd5efdd3e3b840R14. It looks unnecessary. 