### PR TITLE
Bugfix: validate request parameter for POST, PUT, PATCH operations

### DIFF
--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -116,7 +116,9 @@ module Committee
           content_type = headers['Content-Type'].to_s.split(";").first.to_s
 
           # bad performance because when we coerce value, same check
-          return request_operation.validate_request_body(content_type, params, build_openapi_parser_post_option(validator_option))
+          schema_validator_options = build_openapi_parser_post_option(validator_option)
+          request_operation.validate_request_parameter(params, headers, schema_validator_options)
+          request_operation.validate_request_body(content_type, params, schema_validator_options)
         rescue => e
           raise Committee::InvalidRequest.new(e.message)
         end

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -599,7 +599,7 @@ components:
   responses:
     header_integer_required:
       headers:
-        integer:
+        'x-limit':
           schema:
             required: true
             type: integer

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -502,18 +502,35 @@ paths:
   /header:
     get:
       parameters:
-        - name: integer
-          in: header
-          required: true
-          schema:
-            type: integer
+        - $ref: '#/components/parameters/header_integer_required'
       responses:
         '200':
-          headers:
-            x-limit:
-              description: integer
-              schema:
-                type: integer
+          $ref: '#/components/responses/header_integer_required'
+    post:
+      parameters:
+        - $ref: '#/components/parameters/header_integer_required'
+      responses:
+        '200':
+          $ref: '#/components/responses/header_integer_required'
+    put:
+      parameters:
+        - $ref: '#/components/parameters/header_integer_required'
+      responses:
+        '200':
+          $ref: '#/components/responses/header_integer_required'
+    patch:
+      parameters:
+        - $ref: '#/components/parameters/header_integer_required'
+      responses:
+        '200':
+          $ref: '#/components/responses/header_integer_required'
+    delete:
+      parameters:
+        - $ref: '#/components/parameters/header_integer_required'
+      responses:
+        '200':
+          $ref: '#/components/responses/header_integer_required'
+
   /get_endpoint_with_requered_parameter:
     get:
       description: get body test
@@ -570,3 +587,19 @@ components:
             items:
               type: string
               format: date-time
+
+  parameters:
+    header_integer_required:
+      name: integer
+      in: header
+      required: true
+      schema:
+        type: integer
+
+  responses:
+    header_integer_required:
+      headers:
+        integer:
+          schema:
+            required: true
+            type: integer


### PR DESCRIPTION
Currently request parameters are validated just for GET and DELETE.

Add request parameters validation even for POST, PUT, PATCH.
