### PR TITLE
Refactoring: more exhaustive tests for OpenAPI 3 response header validation (same as request validation)

### DIFF
--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -599,7 +599,7 @@ components:
   responses:
     header_integer_required:
       headers:
-        'x-limit':
+        integer:
           schema:
             required: true
             type: integer


### PR DESCRIPTION
After [ota42y/openapi_parser: Bugfix: validate non-nullable response header](https://github.com/ota42y/openapi_parser/pull/54) and 
[interagent/committe: Bugfix: validate request parameter for POST, PUT, PATCH operations](https://github.com/interagent/committee/pull/244) this PR:
- ensures that non-nullable response headers are properly validated
- exhaustively test for all operations 
- brings same [testing style as request_validation ](https://github.com/interagent/committee/blob/master/test/middleware/request_validation_open_api_3_test.rb#L402-L430)