### PR TITLE
Add a filter for request validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Non-boolean options:
 |schema_path| String | supported | supported | Defines the location of the schema file to use for validation. |
 |error_handler| Proc Object | supported | supported | A proc which will be called when error occurs. Take an Error instance as first argument, and request.env as second argument. (e.g. `-> (ex, env) { Raven.capture_exception(ex, extra: { rack_env: env }) }`) |
 |only  | Proc Object | supported | supported | A proc that accepts a Request and returns a boolean. It indicates whether to validate the current request, or not. (e.g. `-> (request) { request.path.start_with?('/something') }`) |
-|except| Proc Object | supported | supported | A proc that accepts a Request and returns a boolean. It indicates whether to skip validation for the current request, or not. (e.g. `-> (request) { request.path.start_with?('/something') }`) |
 
 Note that Hyper-Schema and OpenAPI 2 get the same defaults for options.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Non-boolean options:
 |prefix| String | supported | supported | Mounts the middleware to respond at a configured prefix. (e.g. prefix is '/v1' and request path is '/v1/test' use '/test' definition). |
 |schema_path| String | supported | supported | Defines the location of the schema file to use for validation. |
 |error_handler| Proc Object | supported | supported | A proc which will be called when error occurs. Take an Error instance as first argument, and request.env as second argument. (e.g. `-> (ex, env) { Raven.capture_exception(ex, extra: { rack_env: env }) }`) |
+|only  | Proc Object | supported | supported | A proc that accepts a Request and returns a boolean. It indicates whether to validate the current request, or not. (e.g. `-> (request) { request.path.start_with?('/something') }`) |
+|except| Proc Object | supported | supported | A proc that accepts a Request and returns a boolean. It indicates whether to skip validation for the current request, or not. (e.g. `-> (request) { request.path.start_with?('/something') }`) |
 
 Note that Hyper-Schema and OpenAPI 2 get the same defaults for options.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Non-boolean options:
 |prefix| String | supported | supported | Mounts the middleware to respond at a configured prefix. (e.g. prefix is '/v1' and request path is '/v1/test' use '/test' definition). |
 |schema_path| String | supported | supported | Defines the location of the schema file to use for validation. |
 |error_handler| Proc Object | supported | supported | A proc which will be called when error occurs. Take an Error instance as first argument, and request.env as second argument. (e.g. `-> (ex, env) { Raven.capture_exception(ex, extra: { rack_env: env }) }`) |
-|only  | Proc Object | supported | supported | A proc that accepts a Request and returns a boolean. It indicates whether to validate the current request, or not. (e.g. `-> (request) { request.path.start_with?('/something') }`) |
+|accept_request_filter  | Proc Object | supported | supported | A proc that accepts a Request and returns a boolean. It indicates whether to validate the current request, or not. (e.g. `-> (request) { request.path.start_with?('/something') }`) |
 
 Note that Hyper-Schema and OpenAPI 2 get the same defaults for options.
 

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -13,13 +13,13 @@ module Committee
         @schema = self.class.get_schema(options)
 
         @router = @schema.build_router(options)
-        @only = options[:only] || -> (_) { true }
+        @accept_request_filter = options[:accept_request_filter] || -> (_) { true }
       end
 
       def call(env)
         request = Rack::Request.new(env)
 
-        if @router.includes_request?(request) && should_handle?(request)
+        if @router.includes_request?(request) && @accept_request_filter.call(request)
           handle(request)
         else
           @app.call(request.env)
@@ -49,10 +49,6 @@ module Committee
 
       def build_schema_validator(request)
         @router.build_schema_validator(request)
-      end
-
-      def should_handle?(request)
-        @only.call(request)
       end
     end
   end

--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -14,7 +14,6 @@ module Committee
 
         @router = @schema.build_router(options)
         @only = options[:only] || -> (_) { true }
-        @except = options[:except] || -> (_) { false }
       end
 
       def call(env)
@@ -53,7 +52,7 @@ module Committee
       end
 
       def should_handle?(request)
-        @only.call(request) && !@except.call(request)
+        @only.call(request)
       end
     end
   end

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -429,14 +429,14 @@ describe Committee::Middleware::RequestValidation do
     end
   end
 
-  describe ':only' do
+  describe ':accept_request_filter' do
     [
-      { description: 'when not specified, includes everything', only: nil, expected: { status: 400 } },
-      { description: 'when predicate matches, performs validation', only: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 400 } },
-      { description: 'when predicate does not match, skips validation', only: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
-    ].each do |description:, only:, expected:|
+      { description: 'when not specified, includes everything', accept_request_filter: nil, expected: { status: 400 } },
+      { description: 'when predicate matches, performs validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 400 } },
+      { description: 'when predicate does not match, skips validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
+    ].each do |description:, accept_request_filter:, expected:|
       it description do
-        @app = new_rack_app(prefix: '/v1', schema: open_api_3_schema, only: only)
+        @app = new_rack_app(prefix: '/v1', schema: open_api_3_schema, accept_request_filter: accept_request_filter)
 
         post 'v1/characters', JSON.generate(string_post_1: 1)
 

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -429,22 +429,6 @@ describe Committee::Middleware::RequestValidation do
     end
   end
 
-  describe ':except' do
-    [
-      { description: 'when not specified, does not exclude anything', except: nil, expected: { status: 400 } },
-      { description: 'when predicate matches, skips validation', except: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 200 } },
-      { description: 'when predicate does not match, performs validation', except: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 400 } },
-    ].each do |description:, except:, expected:|
-      it description do
-        @app = new_rack_app(prefix: '/v1', schema: open_api_3_schema, except: except)
-
-        post 'v1/characters', JSON.generate(string_post_1: 1)
-
-        assert_equal expected[:status], last_response.status
-      end
-    end
-  end
-
   describe ':only' do
     [
       { description: 'when not specified, includes everything', only: nil, expected: { status: 400 } },

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -429,6 +429,38 @@ describe Committee::Middleware::RequestValidation do
     end
   end
 
+  describe ':except' do
+    [
+      { description: 'when not specified, does not exclude anything', except: nil, expected: { status: 400 } },
+      { description: 'when predicate matches, skips validation', except: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 200 } },
+      { description: 'when predicate does not match, performs validation', except: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 400 } },
+    ].each do |description:, except:, expected:|
+      it description do
+        @app = new_rack_app(prefix: '/v1', schema: open_api_3_schema, except: except)
+
+        post 'v1/characters', JSON.generate(string_post_1: 1)
+
+        assert_equal expected[:status], last_response.status
+      end
+    end
+  end
+
+  describe ':only' do
+    [
+      { description: 'when not specified, includes everything', only: nil, expected: { status: 400 } },
+      { description: 'when predicate matches, performs validation', only: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 400 } },
+      { description: 'when predicate does not match, skips validation', only: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
+    ].each do |description:, only:, expected:|
+      it description do
+        @app = new_rack_app(prefix: '/v1', schema: open_api_3_schema, only: only)
+
+        post 'v1/characters', JSON.generate(string_post_1: 1)
+
+        assert_equal expected[:status], last_response.status
+      end
+    end
+  end
+
   private
 
   def new_rack_app(options = {})

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -480,22 +480,6 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
-  describe ':except' do
-    [
-      { description: 'when not specified, does not exclude anything', except: nil, expected: { status: 400 } },
-      { description: 'when predicate matches, skips validation', except: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 200 } },
-      { description: 'when predicate does not match, performs validation', except: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 400 } },
-    ].each do |description:, except:, expected:|
-      it description do
-        @app = new_rack_app(prefix: '/v1', schema: hyper_schema, except: except)
-
-        post '/v1/apps', '{x:y}'
-
-        assert_equal expected[:status], last_response.status
-      end
-    end
-  end
-
   describe ':only' do
     [
       { description: 'when not specified, includes everything', only: nil, expected: { status: 400 } },

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -480,14 +480,14 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
-  describe ':only' do
+  describe ':accept_request_filter' do
     [
-      { description: 'when not specified, includes everything', only: nil, expected: { status: 400 } },
-      { description: 'when predicate matches, performs validation', only: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 400 } },
-      { description: 'when predicate does not match, skips validation', only: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
-    ].each do |description:, only:, expected:|
+      { description: 'when not specified, includes everything', accept_request_filter: nil, expected: { status: 400 } },
+      { description: 'when predicate matches, performs validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 400 } },
+      { description: 'when predicate does not match, skips validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
+    ].each do |description:, accept_request_filter:, expected:|
       it description do
-        @app = new_rack_app(prefix: '/v1', schema: hyper_schema, only: only)
+        @app = new_rack_app(prefix: '/v1', schema: hyper_schema, accept_request_filter: accept_request_filter)
 
         post '/v1/apps', '{x:y}'
 

--- a/test/middleware/response_validation_open_api_3_test.rb
+++ b/test/middleware/response_validation_open_api_3_test.rb
@@ -169,14 +169,14 @@ describe Committee::Middleware::ResponseValidation do
     end
   end
 
-  describe ':only' do
+  describe ':accept_request_filter' do
     [
-      { description: 'when not specified, includes everything', only: nil, expected: { status: 500 } },
-      { description: 'when predicate matches, performs validation', only: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 500 } },
-      { description: 'when predicate does not match, skips validation', only: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
-    ].each do |description:, only:, expected:|
+      { description: 'when not specified, includes everything', accept_request_filter: nil, expected: { status: 500 } },
+      { description: 'when predicate matches, performs validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 500 } },
+      { description: 'when predicate does not match, skips validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
+    ].each do |description:, accept_request_filter:, expected:|
       it description do
-        @app = new_response_rack('not_json', {}, schema: open_api_3_schema, prefix: '/v1', only: only)
+        @app = new_response_rack('not_json', {}, schema: open_api_3_schema, prefix: '/v1', accept_request_filter: accept_request_filter)
 
         get 'v1/characters'
 

--- a/test/middleware/response_validation_open_api_3_test.rb
+++ b/test/middleware/response_validation_open_api_3_test.rb
@@ -169,6 +169,38 @@ describe Committee::Middleware::ResponseValidation do
     end
   end
 
+  describe ':except' do
+    [
+      { description: 'when not specified, does not exclude anything', except: nil, expected: { status: 500 } },
+      { description: 'when predicate matches, skips validation', except: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 200 } },
+      { description: 'when predicate does not match, performs validation', except: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 500 } },
+    ].each do |description:, except:, expected:|
+      it description do
+        @app = new_response_rack('not_json', {}, schema: open_api_3_schema, prefix: '/v1', except: except)
+
+        get '/v1/characters'
+
+        assert_equal expected[:status], last_response.status
+      end
+    end
+  end
+
+  describe ':only' do
+    [
+      { description: 'when not specified, includes everything', only: nil, expected: { status: 500 } },
+      { description: 'when predicate matches, performs validation', only: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 500 } },
+      { description: 'when predicate does not match, skips validation', only: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
+    ].each do |description:, only:, expected:|
+      it description do
+        @app = new_response_rack('not_json', {}, schema: open_api_3_schema, prefix: '/v1', only: only)
+
+        get 'v1/characters'
+
+        assert_equal expected[:status], last_response.status
+      end
+    end
+  end
+
   private
 
   def new_response_rack(response, headers = {}, options = {}, rack_options = {})

--- a/test/middleware/response_validation_open_api_3_test.rb
+++ b/test/middleware/response_validation_open_api_3_test.rb
@@ -169,22 +169,6 @@ describe Committee::Middleware::ResponseValidation do
     end
   end
 
-  describe ':except' do
-    [
-      { description: 'when not specified, does not exclude anything', except: nil, expected: { status: 500 } },
-      { description: 'when predicate matches, skips validation', except: -> (request) { request.path.start_with?('/v1/c') }, expected: { status: 200 } },
-      { description: 'when predicate does not match, performs validation', except: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 500 } },
-    ].each do |description:, except:, expected:|
-      it description do
-        @app = new_response_rack('not_json', {}, schema: open_api_3_schema, prefix: '/v1', except: except)
-
-        get '/v1/characters'
-
-        assert_equal expected[:status], last_response.status
-      end
-    end
-  end
-
   describe ':only' do
     [
       { description: 'when not specified, includes everything', only: nil, expected: { status: 500 } },

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -162,22 +162,6 @@ describe Committee::Middleware::ResponseValidation do
     assert_match(/valid JSON/i, last_response.body)
   end
 
-  describe ':except' do
-    [
-      { description: 'when not specified, does not exclude anything', except: nil, expected: { status: 500 } },
-      { description: 'when predicate matches, skips validation', except: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 200 } },
-      { description: 'when predicate does not match, performs validation', except: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 500 } },
-    ].each do |description:, except:, expected:|
-      it description do
-        @app = new_rack_app('not_json', {}, schema: hyper_schema, prefix: '/v1', except: except)
-
-        get '/v1/apps'
-
-        assert_equal expected[:status], last_response.status
-      end
-    end
-  end
-
   describe ':only' do
     [
       { description: 'when not specified, includes everything', only: nil, expected: { status: 500 } },

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -162,14 +162,14 @@ describe Committee::Middleware::ResponseValidation do
     assert_match(/valid JSON/i, last_response.body)
   end
 
-  describe ':only' do
+  describe ':accept_request_filter' do
     [
-      { description: 'when not specified, includes everything', only: nil, expected: { status: 500 } },
-      { description: 'when predicate matches, performs validation', only: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 500 } },
-      { description: 'when predicate does not match, skips validation', only: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
-    ].each do |description:, only:, expected:|
+      { description: 'when not specified, includes everything', accept_request_filter: nil, expected: { status: 500 } },
+      { description: 'when predicate matches, performs validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 500 } },
+      { description: 'when predicate does not match, skips validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
+    ].each do |description:, accept_request_filter:, expected:|
       it description do
-        @app = new_rack_app('not_json', {}, schema: hyper_schema, prefix: '/v1', only: only)
+        @app = new_rack_app('not_json', {}, schema: hyper_schema, prefix: '/v1', accept_request_filter: accept_request_filter)
 
         get '/v1/apps'
 

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -162,6 +162,38 @@ describe Committee::Middleware::ResponseValidation do
     assert_match(/valid JSON/i, last_response.body)
   end
 
+  describe ':except' do
+    [
+      { description: 'when not specified, does not exclude anything', except: nil, expected: { status: 500 } },
+      { description: 'when predicate matches, skips validation', except: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 200 } },
+      { description: 'when predicate does not match, performs validation', except: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 500 } },
+    ].each do |description:, except:, expected:|
+      it description do
+        @app = new_rack_app('not_json', {}, schema: hyper_schema, prefix: '/v1', except: except)
+
+        get '/v1/apps'
+
+        assert_equal expected[:status], last_response.status
+      end
+    end
+  end
+
+  describe ':only' do
+    [
+      { description: 'when not specified, includes everything', only: nil, expected: { status: 500 } },
+      { description: 'when predicate matches, performs validation', only: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 500 } },
+      { description: 'when predicate does not match, skips validation', only: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
+    ].each do |description:, only:, expected:|
+      it description do
+        @app = new_rack_app('not_json', {}, schema: hyper_schema, prefix: '/v1', only: only)
+
+        get '/v1/apps'
+
+        assert_equal expected[:status], last_response.status
+      end
+    end
+  end
+
   private
 
   def new_rack_app(response, headers = {}, options = {})


### PR DESCRIPTION
#### Summary 
This small PR adds `:only` and `:except` to the configuration options.
They allow to whitelist and blacklist the validation based on custom criteria.

Whitelist can be useful in case of a big codebase, without API schema, where the schema is written gradually, over time.

Blacklist can be useful in case of specific path that are non standard, or should not included in the current schema (i.e. internal endpoints with their own schema).