### PR TITLE
Allow path param and request body to be passed at the same time

### DIFF
--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -18,7 +18,8 @@ module Committee
 
         request_unpack(request)
 
-        request.env[validator_option.params_key]&.merge!(path_params) unless path_params.empty?
+        # committee.params
+        request.env[validator_option.params_key]&.merge!('path' => path_params) unless path_params.empty?
 
         request_schema_validation(request)
 
@@ -80,8 +81,11 @@ module Committee
       def copy_coerced_data_to_query_hash(request)
         return if request.env["rack.request.query_hash"].nil? || request.env["rack.request.query_hash"].empty?
 
+        params = request.env[validator_option.params_key]
+        request_params = (params['path'] || {}).merge(params['query'] || {}).merge(params['form_data'] || {}).merge(params['body'] || {})
+
         request.env["rack.request.query_hash"].keys.each do |k|
-          request.env["rack.request.query_hash"][k] = request.env[validator_option.params_key][k]
+          request.env["rack.request.query_hash"][k] = request_params[k]
         end
       end
     end

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -544,6 +544,31 @@ paths:
         '204':
           description: no content
 
+  /request_body_and_path_params/{id}:
+    post:
+      description: request body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+              - data
+              properties:
+                data:
+                  type: string
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: no content
+
 components:
   schemas:
     nested_array:

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -44,6 +44,15 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
+  it "passes given a valid request body and path param" do
+    @app = new_rack_app(schema: open_api_3_schema)
+    params = { "data" => "abc" }
+    header "Content-Type", "application/json"
+    post "/request_body_and_path_params/abc", JSON.generate(params)
+
+    assert_equal 200, last_response.status
+  end
+
   it "passes given a valid parameter on GET endpoint with request body and allow_get_body=true" do
     params = { "data" => "abc" }
 
@@ -66,7 +75,7 @@ describe Committee::Middleware::RequestValidation do
     params = { "datetime_string" => "2016-04-01T16:00:00.000+09:00" }
 
     check_parameter = lambda { |env|
-      assert_equal DateTime, env['committee.params']["datetime_string"].class
+      assert_equal DateTime, env['committee.params']['body']["datetime_string"].class
       [200, {}, []]
     }
 
@@ -108,7 +117,7 @@ describe Committee::Middleware::RequestValidation do
     }
 
     check_parameter = lambda { |env|
-      nested_array = env['committee.params']["nested_array"]
+      nested_array = env['committee.params']['body']["nested_array"]
       first_data = nested_array[0]
       assert_kind_of DateTime, first_data["update_time"]
 
@@ -220,7 +229,7 @@ describe Committee::Middleware::RequestValidation do
     }
 
     check_parameter = lambda { |env|
-      hash = env['committee.params']
+      hash = env['committee.params']['body']
       array = hash['nested_array']
 
       assert_equal DateTime, array.first['update_time'].class
@@ -388,7 +397,7 @@ describe Committee::Middleware::RequestValidation do
 
   it "coerce string to integer" do
     check_parameter_string = lambda { |env|
-      assert env['committee.params']['integer'].is_a?(Integer)
+      assert env['committee.params']['path']['integer'].is_a?(Integer)
       [200, {}, []]
     }
 

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -27,12 +27,12 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
     ]
 
     it 'correct data' do
-      operation_object.validate_request_params(SCHEMA_PROPERTIES_PAIR.to_h, HEADER, @validator_option)
+      operation_object.validate_request_params({ "body" => SCHEMA_PROPERTIES_PAIR.to_h }, HEADER, @validator_option)
       assert true
     end
 
     it 'correct object data' do
-      operation_object.validate_request_params({
+      operation_object.validate_request_params({ "body" => {
                                      "object_1" =>
                                          {
                                              "string_1" => nil,
@@ -40,7 +40,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
                                              "boolean_1" => nil,
                                              "number_1" => nil
                                          }
-                                 },
+                                 }},
                                                HEADER,
                                                @validator_option)
 
@@ -49,7 +49,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
     it 'invalid params' do
       e = assert_raises(Committee::InvalidRequest) {
-        operation_object.validate_request_params({"string" => 1}, HEADER, @validator_option)
+        operation_object.validate_request_params({ "body" => {"string" => 1}}, HEADER, @validator_option)
       }
 
       # FIXME: when ruby 2.3 dropped, fix because ruby 2.3 return Fixnum, ruby 2.4 or later return Integer
@@ -58,10 +58,10 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
     it 'support put method' do
       @method = "put"
-      operation_object.validate_request_params({"string" => "str"}, HEADER, @validator_option)
+      operation_object.validate_request_params({ "body" => {"string" => "str"}}, HEADER, @validator_option)
 
       e = assert_raises(Committee::InvalidRequest) {
-        operation_object.validate_request_params({"string" => 1}, HEADER, @validator_option)
+        operation_object.validate_request_params({ "body" => {"string" => 1}}, HEADER, @validator_option)
       }
 
       # FIXME: when ruby 2.3 dropped, fix because ruby 2.3 return Fixnum, ruby 2.4 or later return Integer
@@ -70,17 +70,17 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
     it 'support patch method' do
       @method = "patch"
-      operation_object.validate_request_params({"integer" => 1}, HEADER, @validator_option)
+      operation_object.validate_request_params({ "body" => {"integer" => 1}}, HEADER, @validator_option)
 
       e = assert_raises(Committee::InvalidRequest) {
-        operation_object.validate_request_params({"integer" => "str"}, HEADER, @validator_option)
+        operation_object.validate_request_params({ "body" => {"integer" => "str"}}, HEADER, @validator_option)
       }
 
       assert_match(/expected integer, but received String: str/i, e.message)
     end
 
     it 'unknown param' do
-      operation_object.validate_request_params({"unknown" => 1}, HEADER, @validator_option)
+      operation_object.validate_request_params({ "body" => {"unknown" => 1}}, HEADER, @validator_option)
     end
 
     describe 'support get method' do
@@ -90,13 +90,13 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
       it 'correct' do
         operation_object.validate_request_params(
-            {"query_string" => "query", "query_integer_list" => [1, 2]},
+            { "query" => {"query_string" => "query", "query_integer_list" => [1, 2]}},
             HEADER,
             @validator_option
         )
 
         operation_object.validate_request_params(
-            {"query_string" => "query", "query_integer_list" => [1, 2], "optional_integer" => 1},
+            { "query" => {"query_string" => "query", "query_integer_list" => [1, 2], "optional_integer" => 1}},
             HEADER,
             @validator_option
         )
@@ -106,7 +106,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
       it 'not exist required' do
         e = assert_raises(Committee::InvalidRequest) {
-          operation_object.validate_request_params({"query_integer_list" => [1, 2]}, HEADER, @validator_option)
+          operation_object.validate_request_params({ "query" => {"query_integer_list" => [1, 2]}}, HEADER, @validator_option)
         }
 
         assert_match(/missing required parameters: query_string/i, e.message)
@@ -115,7 +115,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       it 'invalid type' do
         e = assert_raises(Committee::InvalidRequest) {
           operation_object.validate_request_params(
-              {"query_string" => 1, "query_integer_list" => [1, 2], "optional_integer" => 1},
+              { "query" => {"query_string" => 1, "query_integer_list" => [1, 2], "optional_integer" => 1}},
               HEADER,
               @validator_option
           )
@@ -133,14 +133,14 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       end
 
       it 'correct' do
-        operation_object.validate_request_params({"limit" => "1"}, HEADER, @validator_option)
+        operation_object.validate_request_params({ "form_data" => {"limit" => "1"}}, HEADER, @validator_option)
 
         assert true
       end
 
       it 'invalid type' do
         e = assert_raises(Committee::InvalidRequest) {
-          operation_object.validate_request_params({"limit" => "a"}, HEADER, @validator_option)
+          operation_object.validate_request_params({ "form_data" => {"limit" => "a"}}, HEADER, @validator_option)
         }
 
         assert_match(/expected integer, but received String: a/i, e.message)


### PR DESCRIPTION
Right now it is not possible in open api 3 to set a path param and a request body.

Not sure though if this is the right way but it worked for the spec we are using.