### PR TITLE
fix: parse response body as JSON only when applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Option values and defaults:
 |raise| false | false | Raise an exception on error instead of responding with a generic error body. |
 |validate_success_only| true | false | Also validate non-2xx responses only. |
 |ignore_error| false | false | Validate and ignore result even if validation is error. So always return original data. |
+|parse_response_by_content_type| false | false | Parse response body to JSON only if Content-Type header is 'application/json'. When false, this always optimisitically parses as JSON without checking for Content-Type header. |
 
 No boolean option values:
 

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -35,7 +35,12 @@ module Committee
         response.each do |chunk|
           full_body << chunk
         end
-        data = full_body.empty? ? {} : JSON.parse(full_body)
+
+        data = {}
+        if !full_body.empty? && headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          data = JSON.parse(full_body)
+        end
+
         Committee::SchemaValidator::HyperSchema::ResponseValidator.new(link, validate_success_only: validator_option.validate_success_only).call(status, headers, data)
       end
 

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -37,8 +37,9 @@ module Committee
         end
 
         data = {}
-        if !full_body.empty? && headers.fetch('Content-Type', nil)&.start_with?('application/json')
-          data = JSON.parse(full_body)
+        unless full_body.empty?
+          parse_to_json = !validator_option.parse_response_by_content_type || headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          data = JSON.parse(full_body) if parse_to_json
         end
 
         Committee::SchemaValidator::HyperSchema::ResponseValidator.new(link, validate_success_only: validator_option.validate_success_only).call(status, headers, data)

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -30,7 +30,11 @@ module Committee
         response.each do |chunk|
           full_body << chunk
         end
-        data = full_body.empty? ? {} : JSON.parse(full_body)
+
+        data = {}
+        if !full_body.empty? && headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          data = JSON.parse(full_body)
+        end
 
         strict = test_method
         Committee::SchemaValidator::OpenAPI3::ResponseValidator.

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -32,8 +32,9 @@ module Committee
         end
 
         data = {}
-        if !full_body.empty? && headers.fetch('Content-Type', nil)&.start_with?('application/json')
-          data = JSON.parse(full_body)
+        unless full_body.empty?
+          parse_to_json = !validator_option.parse_response_by_content_type || headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          data = JSON.parse(full_body) if parse_to_json
         end
 
         strict = test_method

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -15,7 +15,8 @@ module Committee
                   :coerce_query_params,
                   :coerce_recursive,
                   :optimistic_json,
-                  :validate_success_only
+                  :validate_success_only,
+                  :parse_response_by_content_type
 
       # Non-boolean options:
       attr_reader :headers_key,
@@ -35,6 +36,7 @@ module Committee
         @check_header        = options.fetch(:check_header, true)
         @coerce_recursive    = options.fetch(:coerce_recursive, true)
         @optimistic_json     = options.fetch(:optimistic_json, false)
+        @parse_response_by_content_type = options.fetch(:parse_response_by_content_type, false)
 
         # Boolean options and have a different value by default
         @allow_get_body      = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)

--- a/test/schema_validator/open_api_3/response_validator_test.rb
+++ b/test/schema_validator/open_api_3/response_validator_test.rb
@@ -29,7 +29,7 @@ describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do
     call_response_validator
   end
 
-  it "passes through a valid response with no registered Content-Type with strict = true" do
+  it "raises InvalidResponse when a valid response with no registered body with strict option" do
     @headers = { "Content-Type" => "application/xml" }
     assert_raises(Committee::InvalidResponse) {
       call_response_validator(true)
@@ -41,7 +41,7 @@ describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do
     call_response_validator
   end
 
-  it "passes through a valid response with no Content-Type with strict option" do
+  it "raises InvalidResponse when a valid response with no Content-Type headers with strict option" do
     @headers = {}
     assert_raises(Committee::InvalidResponse) {
       call_response_validator(true)


### PR DESCRIPTION
This resolves #257

I had a use-case where I am using the Committee::Middleware::ResponseValidation middleware with `strict: true` option, and one of my endpoint returns a HTTP 302 response (with Location header) and has a text/plain content as string ('You are being redirected to ....' as per Rails default).

My OpenAPI 3 spec reflects this correctly. However, it seems the ResponseValidation always assumes the response body is parseable as JSON (not always the case).

I added the code I think would be sufficient to call on `JSON.parse` only when the headers suggest to.
For backwards compatability, this behaviour is set only when `parse_response_by_content_type` is set to `true` (defaults `false`).

I think perhaps this can be improved, and I would like to add some tests as least 🙇 
As of now, `bundle exec rake` command exits 0 on my local testing (ruby 2.6)

