### PR TITLE
remove old ruby code

### DIFF
--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -249,8 +249,7 @@ describe Committee::Middleware::RequestValidation do
     }
     post "/characters", JSON.generate(params)
     assert_equal 400, last_response.status
-    # FIXME: when ruby 2.3 dropped, fix because ruby 2.3 return Fixnum, ruby 2.4 or later return Integer
-    assert_match(/expected string, but received #{1.class}:/i, last_response.body)
+    assert_match(/expected string, but received Integer:/i, last_response.body)
   end
 
   it "rescues JSON errors" do
@@ -279,8 +278,7 @@ describe Committee::Middleware::RequestValidation do
     header "Content-Type", "application/json"
     post "/v1/characters", JSON.generate(params)
     assert_equal 400, last_response.status
-    # FIXME: when ruby 2.3 dropped, fix because ruby 2.3 return Fixnum, ruby 2.4 or later return Integer
-    assert_match(/expected string, but received #{1.class}: /i, last_response.body)
+    assert_match(/expected string, but received Integer: /i, last_response.body)
   end
 
   it "ignores paths outside the prefix" do

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -52,8 +52,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
         operation_object.validate_request_params({"string" => 1}, HEADER, @validator_option)
       }
 
-      # FIXME: when ruby 2.3 dropped, fix because ruby 2.3 return Fixnum, ruby 2.4 or later return Integer
-      assert_match(/expected string, but received #{1.class}: 1/i, e.message)
+      assert_match(/expected string, but received Integer: 1/i, e.message)
     end
 
     it 'support put method' do
@@ -64,8 +63,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
         operation_object.validate_request_params({"string" => 1}, HEADER, @validator_option)
       }
 
-      # FIXME: when ruby 2.3 dropped, fix because ruby 2.3 return Fixnum, ruby 2.4 or later return Integer
-      assert_match(/expected string, but received #{1.class}: 1/i, e.message)
+      assert_match(/expected string, but received Integer: 1/i, e.message)
     end
 
     it 'support patch method' do
@@ -121,8 +119,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
           )
         }
 
-        # FIXME: when ruby 2.3 dropped, fix because ruby 2.3 return Fixnum, ruby 2.4 or later return Integer
-        assert_match(/expected string, but received #{1.class}: 1/i, e.message)
+        assert_match(/expected string, but received Integer: 1/i, e.message)
       end
     end
 


### PR DESCRIPTION
we drop ruby 2.3 so we can remove old ruby code