### PR TITLE
Support OpenAPI 3 remote $ref

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json_schema", "~> 0.14", ">= 0.14.3"
 
   s.add_dependency "rack", ">= 1.5"
-  s.add_dependency "openapi_parser", ">= 0.6.1"
+  s.add_dependency "openapi_parser", ">= 0.11.1"
 
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rack-test", "~> 0.6"

--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -21,14 +21,14 @@ module Committee
     # @param [String] schema_path
     # @return [Committee::Driver]
     def self.load_from_json(schema_path)
-      load_from_data(JSON.parse(File.read(schema_path)))
+      load_from_data(JSON.parse(File.read(schema_path)), schema_path)
     end
 
     # load and build drive from YAML file
     # @param [String] schema_path
     # @return [Committee::Driver]
     def self.load_from_yaml(schema_path)
-      load_from_data(YAML.load_file(schema_path))
+      load_from_data(YAML.load_file(schema_path), schema_path)
     end
 
     # load and build drive from file
@@ -48,10 +48,10 @@ module Committee
     # load and build drive from Hash object
     # @param [Hash] hash
     # @return [Committee::Driver]
-    def self.load_from_data(hash)
+    def self.load_from_data(hash, schema_path = nil)
       if hash['openapi']&.start_with?('3.0.')
-        parser = OpenAPIParser.parse(hash)
-        return Committee::Drivers::OpenAPI3::Driver.new.parse(parser)
+        openapi = OpenAPIParser.parse_with_filepath(hash, schema_path)
+        return Committee::Drivers::OpenAPI3::Driver.new.parse(openapi)
       end
 
       driver = if hash['swagger'] == '2.0'

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -544,6 +544,16 @@ paths:
         '204':
           description: no content
 
+  /ref-sample:
+    get:
+      responses:
+        '200':
+          description: sample of remote schema reference
+          content:
+            application/json:
+              schema:
+                $ref: referee.yaml#/components/schemas/referred_schema
+
 components:
   schemas:
     nested_array:

--- a/test/data/openapi3/referee.yaml
+++ b/test/data/openapi3/referee.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: OpenAPI3 Test
+  description: A Sample file
+servers:
+- url: https://github.com/interagent/committee/
+paths: {}
+components:
+  schemas:
+    referred_schema:
+      type: object
+      properties:
+        sample:
+          type: string
+      required:
+      - sample

--- a/test/middleware/response_validation_open_api_3_test.rb
+++ b/test/middleware/response_validation_open_api_3_test.rb
@@ -99,6 +99,20 @@ describe Committee::Middleware::ResponseValidation do
     assert_match(/valid JSON/i, last_response.body)
   end
 
+  describe "remote schema $ref" do
+    it "passes through a valid response" do
+      @app = new_response_rack(JSON.generate({ "sample" => "value" }), {}, schema: open_api_3_schema)
+      get "/ref-sample"
+      assert_equal 200, last_response.status
+    end
+
+    it "detects a invalid response" do
+      @app = new_response_rack("{}", {}, schema: open_api_3_schema)
+      get "/ref-sample"
+      assert_equal 500, last_response.status
+    end
+  end
+
   describe 'check header' do
     [
       { check_header: true, description: 'valid value', header: { 'integer' => 1 }, expected: { status: 200 } },

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,7 +56,7 @@ def open_api_2_schema
 end
 
 def open_api_3_schema
-  @open_api_3_schema ||= Committee::Drivers.load_from_data(open_api_3_data)
+  @open_api_3_schema ||= Committee::Drivers.load_from_file(open_api_3_schema_path)
 end
 
 # Don't cache this because we'll often manipulate the created hash in tests.


### PR DESCRIPTION
Passing schema path to OpenAPIParser enables remote $ref handling.

`openapi_parser` gem is updated to use this feature.