### PR TITLE
CI: Drop unused Travis directive sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ script: bundle exec rake
 notifications:
   email: false
 
-sudo: false
-
 git:
   depth: 10
 


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).