### PR TITLE
Small fixes to json_schema example app, to align with documented behavior

### DIFF
--- a/examples/json_schema/app.rb
+++ b/examples/json_schema/app.rb
@@ -18,7 +18,7 @@ class App < Sinatra::Base
   #
   # Note that the stub's response can be modified or suppressed. See the POST
   # /apps and PATCH /apps/:id handlers below for examples.
-  use Committee::Middleware::Stub, schema_path: SCHEMA_PATH
+  use Committee::Middleware::Stub, schema_path: SCHEMA_PATH, call: true
 
   # The response validator checks that responses from within the stack are
   # compliant with the JSON schema. It's normally used for verification in
@@ -48,7 +48,7 @@ class App < Sinatra::Base
   # This parameter mixes in some custom information from the request into the
   # default stubbed response and responds with that.
   patch "/apps/:id" do |id|
-    env["committee.response"].merge!(env["committee.params"])
+    JSON.pretty_generate(env["committee.response"].merge!(env["committee.params"]))
   end
 
   delete "/apps/:id" do |id|


### PR DESCRIPTION
Hello! :wave:

I've been playing with committee's `json_schema` example app in order to deepen my understanding of the `ResponseValidation` middleware, and discovered that the app was not behaving as documented in the [README](https://github.com/interagent/committee/blob/master/examples/json_schema/README.md).

Two changes brought it in line with the documented behavior:

1. Without the `call` option set when configuring the stub middleware, the custom behavior described for the `PATCH` and `POST` methods is never executed, and the app's handlers are never called (see [line 33 of the stub middleware](https://github.com/interagent/committee/blob/master/lib/committee/middleware/stub.rb#L33).)

2. Without wrapping the `PATCH` handler's response in `JSON.pretty_generate(...)` (as is done for the `POST` response and the [generated response in the stub middleware](https://github.com/interagent/committee/blob/master/lib/committee/middleware/stub.rb#L52)), the response validation middleware throws a `TypeError: no implicit conversion of Array into String`. 