### PR TITLE
Fix json parse only if applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Option values and defaults:
 |raise| false | false | Raise an exception on error instead of responding with a generic error body. |
 |validate_success_only| true | false | Also validate non-2xx responses only. |
 |ignore_error| false | false | Validate and ignore result even if validation is error. So always return original data. |
+|parse_response_by_content_type| false | false | Parse response body to JSON only if Content-Type header is 'application/json'. When false, this always optimisitically parses as JSON without checking for Content-Type header. |
 
 No boolean option values:
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Option values and defaults:
 |raise| false | false | Raise an exception on error instead of responding with a generic error body. |
 |validate_success_only| true | false | Also validate non-2xx responses only. |
 |ignore_error| false | false | Validate and ignore result even if validation is error. So always return original data. |
-|parse_response_by_content_type| false | false | Parse response body to JSON only if Content-Type header is 'application/json'. When false, this always optimisitically parses as JSON without checking for Content-Type header. |
+|parse_response_by_content_type| false | false | Parse response body to JSON only if Content-Type header is 'application/json'. When false, this always optimistically parses as JSON without checking for Content-Type header. |
 
 No boolean option values:
 

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -38,7 +38,8 @@ module Committee
 
         data = {}
         unless full_body.empty?
-          parse_to_json = !validator_option.parse_response_by_content_type || headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          parse_to_json = !validator_option.parse_response_by_content_type ||
+                          headers.fetch('Content-Type', nil)&.start_with?('application/json')
           data = JSON.parse(full_body) if parse_to_json
         end
 

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -35,7 +35,12 @@ module Committee
         response.each do |chunk|
           full_body << chunk
         end
-        data = full_body.empty? ? {} : JSON.parse(full_body)
+
+        data = {}
+        if !full_body.empty? && headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          data = JSON.parse(full_body)
+        end
+
         Committee::SchemaValidator::HyperSchema::ResponseValidator.new(link, validate_success_only: validator_option.validate_success_only).call(status, headers, data)
       end
 

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -37,8 +37,9 @@ module Committee
         end
 
         data = {}
-        if !full_body.empty? && headers.fetch('Content-Type', nil)&.start_with?('application/json')
-          data = JSON.parse(full_body)
+        unless full_body.empty?
+          parse_to_json = !validator_option.parse_response_by_content_type || headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          data = JSON.parse(full_body) if parse_to_json
         end
 
         Committee::SchemaValidator::HyperSchema::ResponseValidator.new(link, validate_success_only: validator_option.validate_success_only).call(status, headers, data)

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -30,7 +30,11 @@ module Committee
         response.each do |chunk|
           full_body << chunk
         end
-        data = full_body.empty? ? {} : JSON.parse(full_body)
+
+        data = {}
+        if !full_body.empty? && headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          data = JSON.parse(full_body)
+        end
 
         strict = test_method
         Committee::SchemaValidator::OpenAPI3::ResponseValidator.

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -32,8 +32,9 @@ module Committee
         end
 
         data = {}
-        if !full_body.empty? && headers.fetch('Content-Type', nil)&.start_with?('application/json')
-          data = JSON.parse(full_body)
+        unless full_body.empty?
+          parse_to_json = !validator_option.parse_response_by_content_type || headers.fetch('Content-Type', nil)&.start_with?('application/json')
+          data = JSON.parse(full_body) if parse_to_json
         end
 
         strict = test_method

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -31,10 +31,12 @@ module Committee
           full_body << chunk
         end
 
-        data = {}
-        unless full_body.empty?
-          parse_to_json = !validator_option.parse_response_by_content_type || headers.fetch('Content-Type', nil)&.start_with?('application/json')
-          data = JSON.parse(full_body) if parse_to_json
+        parse_to_json = !validator_option.parse_response_by_content_type || 
+                        headers.fetch('Content-Type', nil)&.start_with?('application/json')
+        data = if parse_to_json
+          full_body.empty? ? {} : JSON.parse(full_body)
+        else
+          full_body
         end
 
         strict = test_method

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -15,7 +15,8 @@ module Committee
                   :coerce_query_params,
                   :coerce_recursive,
                   :optimistic_json,
-                  :validate_success_only
+                  :validate_success_only,
+                  :parse_response_by_content_type
 
       # Non-boolean options:
       attr_reader :headers_key,
@@ -35,6 +36,7 @@ module Committee
         @check_header        = options.fetch(:check_header, true)
         @coerce_recursive    = options.fetch(:coerce_recursive, true)
         @optimistic_json     = options.fetch(:optimistic_json, false)
+        @parse_response_by_content_type = options.fetch(:parse_response_by_content_type, false)
 
         # Boolean options and have a different value by default
         @allow_get_body      = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -36,7 +36,12 @@ module Committee
         @check_header        = options.fetch(:check_header, true)
         @coerce_recursive    = options.fetch(:coerce_recursive, true)
         @optimistic_json     = options.fetch(:optimistic_json, false)
-        @parse_response_by_content_type = options.fetch(:parse_response_by_content_type, false)
+        @parse_response_by_content_type = if options[:parse_response_by_content_type].nil?
+          Committee.warn_deprecated('Committee: please set parse_response_by_content_type = false because we\'ll change default value in next major version.') 
+          false
+        else
+          options.fetch(:parse_response_by_content_type)
+        end
 
         # Boolean options and have a different value by default
         @allow_get_body      = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -6,6 +6,18 @@ info:
 servers:
 - url: https://github.com/interagent/committee/
 paths:
+  /csv:
+    get:
+      description: get csv
+      responses:
+        '200':
+          description: success
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+
   /characters:
     get:
       description: get characters

--- a/test/middleware/response_validation_open_api_3_test.rb
+++ b/test/middleware/response_validation_open_api_3_test.rb
@@ -34,6 +34,14 @@ describe Committee::Middleware::ResponseValidation do
     assert_equal 200, last_response.status
   end
 
+  it "passes through a invalid json with parse_response_by_content_type option" do
+    @app = new_response_rack("csv response", { "Content-Type" => "test/csv"}, schema: open_api_3_schema, parse_response_by_content_type: true)
+
+    get "/csv"
+
+    assert_equal 200, last_response.status
+  end
+
   it "passes through not definition" do
     @app = new_response_rack(JSON.generate(CHARACTERS_RESPONSE), {}, schema: open_api_3_schema)
     get "/no_data"

--- a/test/schema_validator/open_api_3/response_validator_test.rb
+++ b/test/schema_validator/open_api_3/response_validator_test.rb
@@ -29,7 +29,7 @@ describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do
     call_response_validator
   end
 
-  it "passes through a valid response with no registered Content-Type with strict = true" do
+  it "raises InvalidResponse when a valid response with no registered body with strict option" do
     @headers = { "Content-Type" => "application/xml" }
     assert_raises(Committee::InvalidResponse) {
       call_response_validator(true)
@@ -41,7 +41,7 @@ describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do
     call_response_validator
   end
 
-  it "passes through a valid response with no Content-Type with strict option" do
+  it "raises InvalidResponse when a valid response with no Content-Type headers with strict option" do
     @headers = {}
     assert_raises(Committee::InvalidResponse) {
       call_response_validator(true)


### PR DESCRIPTION
This is the pull request based on https://github.com/interagent/committee/pull/258 . 
I made some modification so we can pass body to `openapi_validator` even if it is not a json object.