### PR TITLE
Don't rescue JSON::ParserError

### DIFF
--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -22,11 +22,6 @@ module Committee
 
           raise if @raise
           return @error_class.new(500, :invalid_response, $!.message).render unless @ignore_error
-        rescue JSON::ParserError
-          handle_exception($!, request.env)
-
-          raise Committee::InvalidResponse if @raise
-          return @error_class.new(500, :invalid_response, "Response wasn't valid JSON.").render unless @ignore_error
         end
 
         [status, headers, response]

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -46,9 +46,9 @@ describe Committee::Middleware::ResponseValidation do
 
   it "detects a response invalid due to not being JSON" do
     @app = new_rack_app("{_}", {}, schema: hyper_schema)
-    get "/apps"
-    assert_equal 500, last_response.status
-    assert_match(/valid JSON/i, last_response.body)
+    assert_raises(JSON::ParserError) do
+      get "/apps"
+    end
   end
 
   it "ignores a non-2xx invalid response" do
@@ -64,13 +64,6 @@ describe Committee::Middleware::ResponseValidation do
     assert_match(/Invalid response/i, last_response.body)
   end
 
-  it "optionally validates non-2xx invalid responses with invalid json" do
-    @app = new_rack_app("{_}", {}, app_status: 404, validate_success_only: false, schema: hyper_schema)
-    get "/apps"
-    assert_equal 500, last_response.status
-    assert_match(/valid JSON/i, last_response.body)
-  end
-
   it "passes through a 204 (no content) response" do
     @app = new_rack_app("", {}, app_status: 204, schema: hyper_schema)
     get "/apps"
@@ -84,30 +77,23 @@ describe Committee::Middleware::ResponseValidation do
     assert_match("[{x:y}]", last_response.body)
   end
 
-  it "rescues JSON errors" do
-    @app = new_rack_app("[{x:y}]", {}, schema: hyper_schema, validate_success_only: false)
-    get "/apps"
-    assert_equal 500, last_response.status
-    assert_match(/valid json/i, last_response.body)
-  end
-
-  it "calls error_handler (has a arg) when it rescues JSON errors" do
+  it "calls error_handler (has a arg) when it rescues invalid response" do
     called_err = nil
     pr = ->(e) { called_err = e }
-    @app = new_rack_app("[{x:y}]", {}, schema: hyper_schema, error_handler: pr)
+    @app = new_rack_app("{}", {}, schema: hyper_schema, error_handler: pr)
     _, err = capture_io do
       get "/apps"
     end
-    assert_kind_of JSON::ParserError, called_err
+    assert_kind_of Committee::InvalidResponse, called_err
     assert_match(/\[DEPRECATION\]/i, err)
   end
 
-  it "calls error_handler (has two args) when it rescues JSON errors" do
+  it "calls error_handler (has two args) when it rescues invalid response" do
     called_err = nil
     pr = ->(e, _env) { called_err = e }
-    @app = new_rack_app("[{x:y}]", {}, schema: hyper_schema, error_handler: pr)
+    @app = new_rack_app("{}", {}, schema: hyper_schema, error_handler: pr)
     get "/apps"
-    assert_kind_of JSON::ParserError, called_err
+    assert_kind_of Committee::InvalidResponse, called_err
   end
 
   it "takes a prefix" do
@@ -115,37 +101,6 @@ describe Committee::Middleware::ResponseValidation do
       schema: hyper_schema)
     get "/v1/apps"
     assert_equal 200, last_response.status
-  end
-
-  it "rescues JSON errors" do
-    @app = new_rack_app("[{x:y}]", {}, raise: true, schema: hyper_schema)
-    assert_raises(Committee::InvalidResponse) do
-      get "/apps"
-    end
-  end
-
-  it "calls error_handler (has a arg) when it rescues JSON errors" do
-    called_err = nil
-    pr = ->(e) { called_err = e }
-    @app = new_rack_app("[{x:y}]", {}, raise: true, schema: hyper_schema, error_handler: pr)
-    assert_raises(Committee::InvalidResponse) do
-      _, err = capture_io do
-        get "/apps"
-      end
-
-      assert_kind_of JSON::ParserError, called_err
-      assert_match(/\[DEPRECATION\]/i, err)
-    end
-  end
-
-  it "calls error_handler (has two args) when it rescues JSON errors" do
-    called_err = nil
-    pr = ->(e, _env) { called_err = e }
-    @app = new_rack_app("[{x:y}]", {}, raise: true, schema: hyper_schema, error_handler: pr)
-    assert_raises(Committee::InvalidResponse) do
-      get "/apps"
-      assert_kind_of JSON::ParserError, called_err
-    end
   end
 
   it "passes through a valid response for OpenAPI" do
@@ -157,27 +112,8 @@ describe Committee::Middleware::ResponseValidation do
 
   it "detects an invalid response for OpenAPI" do
     @app = new_rack_app("{_}", {}, schema: open_api_2_schema)
-    get "/api/pets"
-    assert_equal 500, last_response.status
-    assert_match(/valid JSON/i, last_response.body)
-  end
-
-  describe ':accept_request_filter' do
-    [
-      { description: 'when not specified, includes everything', accept_request_filter: nil, expected: { status: 500 } },
-      { description: 'when predicate matches, performs validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/a') }, expected: { status: 500 } },
-      { description: 'when predicate does not match, skips validation', accept_request_filter: -> (request) { request.path.start_with?('/v1/x') }, expected: { status: 200 } },
-    ].each do |h|
-      description = h[:description]
-      accept_request_filter = h[:accept_request_filter]
-      expected = h[:expected]
-      it description do
-        @app = new_rack_app('not_json', {}, schema: hyper_schema, prefix: '/v1', accept_request_filter: accept_request_filter)
-
-        get '/v1/apps'
-
-        assert_equal expected[:status], last_response.status
-      end
+    assert_raises(JSON::ParserError) do
+      get "/api/pets"
     end
   end
 


### PR DESCRIPTION
Resolve #277

When app server provides multiple format not only json but html or xml,
it's inconvenient that response validation middleware handles `JSON::ParserError`.

So I thoght response response middleware should not handle `JSON::ParserError` exception.

@ota42y What do you think about it ?