### PR TITLE
Hold original exception only openapi3

### DIFF
--- a/lib/committee/errors.rb
+++ b/lib/committee/errors.rb
@@ -8,9 +8,21 @@ module Committee
   end
 
   class InvalidRequest < Error
+    attr_reader :original_error
+
+    def initialize(error_message=nil, original_error: nil)
+      @original_error = original_error
+      super(error_message)
+    end
   end
 
   class InvalidResponse < Error
+    attr_reader :original_error
+
+    def initialize(error_message=nil, original_error: nil)
+      @original_error = original_error
+      super(error_message)
+    end
   end
 
   class NotFound < Error

--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -23,7 +23,7 @@ module Committee
 
           request_operation.validate_path_params(options)
         rescue OpenAPIParser::OpenAPIError => e
-          raise Committee::InvalidRequest.new(e.message)
+          raise Committee::InvalidRequest.new(e.message, original_error: e)
         end
 
         # @param [Boolean] strict when not content_type or status code definition, raise error
@@ -32,7 +32,7 @@ module Committee
 
           return request_operation.validate_response_body(response_body, response_validate_options(strict, check_header))
         rescue OpenAPIParser::OpenAPIError => e
-          raise Committee::InvalidResponse.new(e.message)
+          raise Committee::InvalidResponse.new(e.message, original_error: e)
         end
 
         def validate_request_params(params, headers, validator_option)
@@ -109,7 +109,7 @@ module Committee
           # bad performance because when we coerce value, same check
           request_operation.validate_request_parameter(params, headers, build_openapi_parser_get_option(validator_option))
         rescue OpenAPIParser::OpenAPIError => e
-          raise Committee::InvalidRequest.new(e.message)
+          raise Committee::InvalidRequest.new(e.message, original_error: e)
         end
 
         def validate_post_request_params(params, headers, validator_option)
@@ -120,7 +120,7 @@ module Committee
           request_operation.validate_request_parameter(params, headers, schema_validator_options)
           request_operation.validate_request_body(content_type, params, schema_validator_options)
         rescue => e
-          raise Committee::InvalidRequest.new(e.message)
+          raise Committee::InvalidRequest.new(e.message, original_error: e)
         end
 
         def response_validate_options(strict, check_header)

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -58,6 +58,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       }
 
       assert_match(/expected string, but received Integer: 1/i, e.message)
+      assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
     end
 
     it 'support put method' do
@@ -69,6 +70,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       }
 
       assert_match(/expected string, but received Integer: 1/i, e.message)
+      assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
     end
 
     it 'support patch method' do
@@ -80,6 +82,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       }
 
       assert_match(/expected integer, but received String: str/i, e.message)
+      assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
     end
 
     it 'unknown param' do
@@ -113,6 +116,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
         }
 
         assert_match(/missing required parameters: query_string/i, e.message)
+        assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
       end
 
       it 'invalid type' do
@@ -125,6 +129,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
         }
 
         assert_match(/expected string, but received Integer: 1/i, e.message)
+        assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
       end
     end
 
@@ -146,6 +151,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
         }
 
         assert_match(/expected integer, but received String: a/i, e.message)
+        assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
       end
     end
 

--- a/test/schema_validator/open_api_3/response_validator_test.rb
+++ b/test/schema_validator/open_api_3/response_validator_test.rb
@@ -36,9 +36,10 @@ describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do
 
   it "raises InvalidResponse when a valid response with no registered body with strict option" do
     @headers = { "Content-Type" => "application/xml" }
-    assert_raises(Committee::InvalidResponse) {
+    e = assert_raises(Committee::InvalidResponse) {
       call_response_validator(true)
     }
+    assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
   end
 
   it "passes through a valid response with no Content-Type" do
@@ -48,9 +49,10 @@ describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do
 
   it "raises InvalidResponse when a valid response with no Content-Type headers with strict option" do
     @headers = {}
-    assert_raises(Committee::InvalidResponse) {
+    e = assert_raises(Committee::InvalidResponse) {
       call_response_validator(true)
     }
+    assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
   end
 
   it "passes through a valid list response" do


### PR DESCRIPTION
I want to handle the OpenAPI3 original exceptions for more advanced error handling.