### PR TITLE
Make check for complex JSON types more strict

### DIFF
--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -16,7 +16,7 @@ module Committee
     def call
       # if Content-Type is empty or JSON, and there was a request body, try to
       # interpret it as JSON
-      params = if !@request.media_type || @request.media_type =~ %r{application/.*json}
+      params = if !@request.media_type || @request.media_type =~ %r{application/(?:.*\+)?json}
         parse_json
       elsif @optimistic_json
         begin

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -13,6 +13,16 @@ describe Committee::RequestUnpacker do
     assert_equal({ "x" => "y" }, params)
   end
 
+  it "unpacks JSON on Content-Type: application/vnd.api+json" do
+    env = {
+      "CONTENT_TYPE" => "application/vnd.api+json",
+      "rack.input"   => StringIO.new('{"x":"y"}'),
+    }
+    request = Rack::Request.new(env)
+    params, _ = Committee::RequestUnpacker.new(request).call
+    assert_equal({ "x" => "y" }, params)
+  end
+
   it "unpacks JSON on no Content-Type" do
     env = {
       "rack.input"   => StringIO.new('{"x":"y"}'),
@@ -20,6 +30,16 @@ describe Committee::RequestUnpacker do
     request = Rack::Request.new(env)
     params, _ = Committee::RequestUnpacker.new(request).call
     assert_equal({ "x" => "y" }, params)
+  end
+
+  it "doesn't unpack JSON on application/x-ndjson" do
+    env = {
+      "CONTENT_TYPE" => "application/x-ndjson",
+      "rack.input"   => StringIO.new('{"x":"y"}\n{"a":"b"}'),
+    }
+    request = Rack::Request.new(env)
+    params, _ = Committee::RequestUnpacker.new(request).call
+    assert_equal({}, params)
   end
 
   it "doesn't unpack JSON under other Content-Types" do


### PR DESCRIPTION
#64 introduced the ability to parse complex JSON types such as `application/vnd.api+json`. Unfortunately, the check implemented breaks `committee` for certain extensions of JSON such as [`application/x-ndjson`](http://ndjson.org/).

This PR attempts to make the check more strictly match the format mentioned in #64 by ensuring that anything preceding `json` ends with `+`. An alternative suggestion would be to not unpack requests with a content type of `application/x-.+`.