### PR TITLE
Put deprecation warning together in one line

### DIFF
--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -42,11 +42,7 @@ module Committee
         if @error_handler.arity > 1
           @error_handler.call(e, env)
         else
-          warn <<-MESSAGE
-          [DEPRECATION] Using `error_handler.call(exception)` is deprecated and will be change to
-            `error_handler.call(exception, request.env)` in next major version.
-          MESSAGE
-
+          warn '[DEPRECATION] Using `error_handler.call(exception)` is deprecated and will be change to `error_handler.call(exception, request.env)` in next major version.'
           @error_handler.call(e)
         end
       end

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -46,11 +46,7 @@ module Committee
         if @error_handler.arity > 1
           @error_handler.call(e, env)
         else
-          warn <<-MESSAGE
-          [DEPRECATION] Using `error_handler.call(exception)` is deprecated and will be change to
-            `error_handler.call(exception, request.env)` in next major version.
-          MESSAGE
-
+          warn '[DEPRECATION] Using `error_handler.call(exception)` is deprecated and will be change to `error_handler.call(exception, request.env)` in next major version.'
           @error_handler.call(e)
         end
       end

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -58,12 +58,7 @@ module Committee
       def old_behavior
         old_assert_behavior = committee_options.fetch(:old_assert_behavior, nil)
         if old_assert_behavior.nil?
-          warn <<-MSG
-          [DEPRECATION] now assert_schema_conform check response schema only.
-            but we will change check request and response in future major version.
-            so if you want to conform response only, please use assert_response_schema_confirm,
-            or you can suppress this message and keep old behavior by setting old_assert_behavior=true.
-          MSG
+          warn '[DEPRECATION] now assert_schema_conform check response schema only. but we will change check request and response in future major version. so if you want to conform response only, please use assert_response_schema_confirm, or you can suppress this message and keep old behavior by setting old_assert_behavior=true.'
           old_assert_behavior = true
         end
         old_assert_behavior


### PR DESCRIPTION
## Background

The existing deprecation warning contains a lot of funny whitespaces (maybe we should use `<<~` instead of `<<-`), but I think the source of the problem is that the warning message is printed across multiple lines.

## Changes

In this pull request, I'll put it together in one line by removing line breaks and all unnecessary spaces.

### Before

This is a snippet of output from `bundle exec rake`:

```
.          [DEPRECATION] now assert_schema_conform check response schema only.
            but we will change check request and response in future major version.
            so if you want to conform response only, please use assert_response_schema_confirm,
            or you can suppress this message and keep old behavior by setting old_assert_behavior=true.
.          [DEPRECATION] now assert_schema_conform check response schema only.
            but we will change check request and response in future major version.
            so if you want to conform response only, please use assert_response_schema_confirm,
            or you can suppress this message and keep old behavior by setting old_assert_behavior=true.
...........................................................................

Finished in 3.028900s, 135.3627 runs/s, 263.1318 assertions/s.
```

### After

```
.[DEPRECATION] now assert_schema_conform check response schema only. but we will change check request and response in future major version. so if you want to conform response only, please use assert_response_schema_confirm, or you can suppress this message and keep old behavior by setting old_assert_behavior=true.
.[DEPRECATION] now assert_schema_conform check response schema only. but we will change check request and response in future major version. so if you want to conform response only, please use assert_response_schema_confirm, or you can suppress this message and keep old behavior by setting old_assert_behavior=true.
................................................................................................................................

Finished in 3.032245s, 135.2134 runs/s, 262.8416 assertions/s.
```