### PR TITLE
Improve deprecation messages

### DIFF
--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -16,9 +16,7 @@ module Committee
   end
 
   def self.warn_deprecated(message)
-    if !$VERBOSE.nil?
-      $stderr.puts(message)
-    end
+    warn(message)
   end
 end
 

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -16,7 +16,7 @@ module Committee
   end
 
   def self.warn_deprecated(message)
-    warn(message)
+    warn("[DEPRECATION] #{message}")
   end
 end
 

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -42,7 +42,7 @@ module Committee
         if @error_handler.arity > 1
           @error_handler.call(e, env)
         else
-          warn '[DEPRECATION] Using `error_handler.call(exception)` is deprecated and will be change to `error_handler.call(exception, request.env)` in next major version.'
+          Committee.warn_deprecated('Using `error_handler.call(exception)` is deprecated and will be change to `error_handler.call(exception, request.env)` in next major version.')
           @error_handler.call(e)
         end
       end

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -46,7 +46,7 @@ module Committee
         if @error_handler.arity > 1
           @error_handler.call(e, env)
         else
-          warn '[DEPRECATION] Using `error_handler.call(exception)` is deprecated and will be change to `error_handler.call(exception, request.env)` in next major version.'
+          Committee.warn_deprecated('Using `error_handler.call(exception)` is deprecated and will be change to `error_handler.call(exception, request.env)` in next major version.')
           @error_handler.call(e)
         end
       end

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -58,7 +58,7 @@ module Committee
       def old_behavior
         old_assert_behavior = committee_options.fetch(:old_assert_behavior, nil)
         if old_assert_behavior.nil?
-          Committee.warn_deprecated('now assert_schema_conform check response schema only. but we will change check request and response in future major version. so if you want to conform response only, please use assert_response_schema_confirm, or you can suppress this message and keep old behavior by setting old_assert_behavior=true.')
+          Committee.warn_deprecated('Now assert_schema_conform check response schema only. but we will change check request and response in future major version. so if you want to conform response only, please use assert_response_schema_confirm, or you can suppress this message and keep old behavior by setting old_assert_behavior=true.')
           old_assert_behavior = true
         end
         old_assert_behavior

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -58,7 +58,7 @@ module Committee
       def old_behavior
         old_assert_behavior = committee_options.fetch(:old_assert_behavior, nil)
         if old_assert_behavior.nil?
-          warn '[DEPRECATION] now assert_schema_conform check response schema only. but we will change check request and response in future major version. so if you want to conform response only, please use assert_response_schema_confirm, or you can suppress this message and keep old behavior by setting old_assert_behavior=true.'
+          Committee.warn_deprecated('now assert_schema_conform check response schema only. but we will change check request and response in future major version. so if you want to conform response only, please use assert_response_schema_confirm, or you can suppress this message and keep old behavior by setting old_assert_behavior=true.')
           old_assert_behavior = true
         end
         old_assert_behavior

--- a/test/committee_test.rb
+++ b/test/committee_test.rb
@@ -42,7 +42,7 @@ describe Committee do
 
       $VERBOSE = true
       Committee.warn_deprecated "blah"
-      assert_equal "blah\n", $stderr.string
+      assert_equal "[DEPRECATION] blah\n", $stderr.string
     ensure
       $stderr = old_stderr
       $VERBOSE = old_verbose


### PR DESCRIPTION
## Background

It's easier to understand if all the warning messages from committee are written in the same format like `[DEPRECATION] ...`, and I think this logic should be implemented using the same method.

I found `Committee.warn_deprecated` method for this purpose, so I tried to replace all deprecation warnings logic with this method.

## Changes

### Committee::SchemaValidator::Option#initialize

This will affect the following message on this method:

> Committee: please set parse_response_by_content_type = false because we\'ll change default value in next major version.

chaning it to:

> [DEPRECATION] Committee: please set parse_response_by_content_type = false because we\'ll change default value in next major version.

### Committee::Test::Methods#old_behavior

Added a minor capitalization change on this method, chaning:

> [DEPRECATION] now assert_schema_conform check...

to:

> [DEPRECATION] Now assert_schema_conform check...