### PR TITLE
add request to validation error

### DIFF
--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -21,14 +21,14 @@ module Committee
         rescue Committee::BadRequest, Committee::InvalidRequest
           handle_exception($!, request.env)
           raise if @raise
-          return @error_class.new(400, :bad_request, $!.message).render unless @ignore_error
+          return @error_class.new(400, :bad_request, $!.message, request).render unless @ignore_error
         rescue Committee::NotFound => e
           raise if @raise
-          return @error_class.new(404, :not_found, e.message).render unless @ignore_error
+          return @error_class.new(404, :not_found, e.message, request).render unless @ignore_error
         rescue JSON::ParserError
           handle_exception($!, request.env)
           raise Committee::InvalidRequest if @raise
-          return @error_class.new(400, :bad_request, "Request body wasn't valid JSON.").render unless @ignore_error
+          return @error_class.new(400, :bad_request, "Request body wasn't valid JSON.", request).render unless @ignore_error
         end
 
         @app.call(request.env)

--- a/lib/committee/validation_error.rb
+++ b/lib/committee/validation_error.rb
@@ -2,12 +2,13 @@
 
 module Committee
   class ValidationError
-    attr_reader :id, :message, :status
+    attr_reader :id, :message, :status, :request
 
-    def initialize(status, id, message)
+    def initialize(status, id, message, request = nil)
       @status = status
       @id = id
       @message = message
+      @request = request
     end
 
     def error_body


### PR DESCRIPTION
Currently, when I try to customize the error_body of the ValidationError class, it can only contain id, status and message.
I would like to include the request object in this error_body, because I especially want to include the request_id in the error_body.