### PR TITLE
Update RequestValidation's examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ tags
 Gemfile.lock
 !/examples/openapi3/Gemfile.lock
 !/examples/json_schema/Gemfile.lock
+!/examples/heroku_api/Gemfile.lock
 .DS_Store
 /coverage/

--- a/README.md
+++ b/README.md
@@ -59,27 +59,27 @@ Some examples of use:
 ``` bash
 # missing required parameter
 $ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api"}'
-{"id":"invalid_params","message":"Require params: recipient."}
+{"id":"bad_request","message":"#/paths/~1account~1app-transfers/post/requestBody/content/application~1json/schema missing required parameters: recipient"}
 
 # missing required parameter (should have &query=...)
 $ curl -X GET http://localhost:9292/search?category=all
-{"id":"invalid_params","message":"Require params: query."}
+{"id":"bad_request","message":"#/paths/~1search/get missing required parameters: query"}
 
 # contains an unknown parameter
 $ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api","recipient":"api@heroku.com","sender":"api@heroku.com"}'
-{"id":"invalid_params","message":"Unknown params: sender."}
+{"id":"bad_request","message":"#/paths/~1account~1app-transfers/post/requestBody/content/application~1json/schema does not define properties: sender"}
 
 # invalid type
 $ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api","recipient":7}'
-{"id":"invalid_params","message":"Invalid type for key \"recipient\": expected 7 to be [\"string\"]."}
+{"id":"bad_request","message":"#/paths/~1account~1app-transfers/post/requestBody/content/application~1json/schema/properties/recipient expected string, but received Integer: 7"}
 
 # invalid format (supports date-time, email, uuid)
-$ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api","recipient":"api@heroku"}'
-{"id":"invalid_params","message":"Invalid format for key \"recipient\": expected \"api@heroku\" to be \"email\"."
+$ curl -X POST http://localhost:9292/account/app-transfers -H "Content-Type: application/json" -d '{"app":"heroku-api","recipient":"matz"}'
+{"id":"bad_request","message":"#/paths/~1account~1app-transfers/post/requestBody/content/application~1json/schema/properties/recipient email address format does not match value: matz"}
 
 # invalid pattern
 $ curl -X POST http://localhost:9292/apps -H "Content-Type: application/json" -d '{"name":"$#%"}'
-{"id":"invalid_params","message":"Invalid pattern for key \"name\": expected $#% to match \"(?-mix:^[a-z][a-z0-9-]{3,30}$)\"."}
+{"id":"bad_request","message":"#/paths/~1apps/post/requestBody/content/application~1json/schema/properties/name pattern ^[a-z][a-z0-9-]{3,50}$ does not match value: $#%"}
 ```
 
 ## Committee::Middleware::Stub
@@ -286,9 +286,9 @@ end
 Please set `'action_dispatch.request.request_parameters'` to `params_key` option.
 
 ```
-use Committee::Middleware::RequestValidation, 
-      schema_path: 'docs/schema.json', 
-      coerce_date_times: true, 
+use Committee::Middleware::RequestValidation,
+      schema_path: 'docs/schema.json',
+      coerce_date_times: true,
       params_key: 'action_dispatch.request.request_parameters'
 ```
 
@@ -331,7 +331,7 @@ Important changes are also described below.
 
 ### Upgrading from Committee 4.* to 5.*
 
-Committee 5.* has few breaking changes so we recommend upgrading to the latest release on 4.* and fixing any deprecation errors you see before upgrading.  
+Committee 5.* has few breaking changes so we recommend upgrading to the latest release on 4.* and fixing any deprecation errors you see before upgrading.
 (Now we doesn't release 5.* yet)
 
 - change `parse_response_by_content_type`'s default value from `false` to `true`.
@@ -403,9 +403,9 @@ end
 
 The default assertion option in 2.* was `validate_success_only=true`, but this becomes `validate_success_only=false` in 3.*. For the smoothest possible upgrade, you should set it to `false` in your test suite before upgrading to 3.*.
 
-**Test schema coverage**  
-You can check how much of your API schema your tests have covered.  
-NOTICE: Currently committee only supports schema coverage for **openapi** schemas, and only checks coverage on responses, via `assert_response_schema_confirm` or `assert_schema_conform` methods.  
+**Test schema coverage**
+You can check how much of your API schema your tests have covered.
+NOTICE: Currently committee only supports schema coverage for **openapi** schemas, and only checks coverage on responses, via `assert_response_schema_confirm` or `assert_schema_conform` methods.
 Usage:
 1. Set schema_coverage option of `committee_options`
 2. Use `assert_response_schema_confirm` or `assert_schema_conform`

--- a/examples/heroku_api/Gemfile
+++ b/examples/heroku_api/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "committee", path: "./../../"
+gem "sinatra"

--- a/examples/heroku_api/Gemfile.lock
+++ b/examples/heroku_api/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: ../..
+  specs:
+    committee (4.3.0)
+      json_schema (~> 0.14, >= 0.14.3)
+      openapi_parser (>= 0.11.1)
+      rack (>= 1.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json_schema (0.20.9)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    openapi_parser (0.12.1)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    ruby2_keywords (0.0.2)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  committee!
+  sinatra
+
+BUNDLED WITH
+   2.1.4

--- a/examples/heroku_api/app.rb
+++ b/examples/heroku_api/app.rb
@@ -1,0 +1,15 @@
+require 'sinatra'
+require 'committee'
+
+set :port, 9292
+
+use Committee::Middleware::RequestValidation, schema_path: './openapi.yaml', coerce_date_times: true
+
+post '/account/app-transfers' do
+end
+
+get '/search' do
+end
+
+post '/apps' do
+end

--- a/examples/heroku_api/openapi.yaml
+++ b/examples/heroku_api/openapi.yaml
@@ -1,0 +1,55 @@
+openapi: '3.0.2'
+info:
+  title: Heroku API
+  version: '1.0'
+servers:
+  - url: http://localhost:5000
+paths:
+  /account/app-transfers:
+    post:
+      responses:
+        '201':
+          description: Created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+                - app
+                - recipient
+              properties:
+                recipient:
+                  type: string
+                  format: email
+                app:
+                  type: string
+  /search:
+    get:
+      responses:
+        '200':
+          description: OK
+      parameters:
+        - in: query
+          name: query
+          required: true
+          schema:
+            type: string
+  /apps:
+    post:
+      responses:
+        '201':
+          description: Created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  pattern: ^[a-z][a-z0-9-]{3,50}$


### PR DESCRIPTION
In this pull request, we are:
- adding a new Sinatra app "heroku_api" to the examples folder;
- updating the section about the RequestValidation in the README file so that the invalid responses match exactly what is returned by Committee.

The new app provides the endpoints documented in the README of the project, so we can use it to check how Committee is handling it.

The new app was implemented following a simplistic approach, so it has the minimum to work as a testing tool for the examples listed in the project's documentation.

PS. my editor trimmed trailing whitespace from the README file. I hope this is fine.