### PR TITLE
Disable coerece_form_params option in the case of application/json

### DIFF
--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -90,8 +90,12 @@ module Committee
         end
 
         # @return [OpenAPIParser::SchemaValidator::Options]
-        def build_openapi_parser_post_option(validator_option)
-          coerce_value = validator_option.coerce_form_params
+        def build_openapi_parser_post_option(validator_option, content_type)
+          coerce_value = if content_type =~ %r{application/(?:.*\+)?json}
+                           false
+                         else
+                           validator_option.coerce_form_params
+                         end
           datetime_coerce_class = validator_option.coerce_date_times ? DateTime : nil
           validate_header = validator_option.check_header
           OpenAPIParser::SchemaValidator::Options.new(coerce_value: coerce_value,
@@ -120,7 +124,7 @@ module Committee
           content_type = headers['Content-Type'].to_s.split(";").first.to_s
 
           # bad performance because when we coerce value, same check
-          schema_validator_options = build_openapi_parser_post_option(validator_option)
+          schema_validator_options = build_openapi_parser_post_option(validator_option, content_type)
           request_operation.validate_request_parameter(params, headers, schema_validator_options)
           request_operation.validate_request_body(content_type, params, schema_validator_options)
         rescue => e

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -10,8 +10,10 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       @path = '/validate'
       @method = 'post'
 
-      # TODO: delete when 5.0.0 released because default value changed
       options = {}
+      options[:coerce_form_params] = true
+
+      # TODO: delete when 5.0.0 released because default value changed
       options[:parse_response_by_content_type] = true if options[:parse_response_by_content_type] == nil
 
       @validator_option = Committee::SchemaValidator::Option.new(options, open_api_3_schema, :open_api_3)
@@ -58,6 +60,21 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       }
 
       assert_match(/expected string, but received Integer: 1/i, e.message)
+      assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
+    end
+
+    it 'coercing for application/xml' do
+      header = { 'Content-Type' => 'application/xml' }
+      operation_object.validate_request_params({'integer' => '1'}, header, @validator_option)
+      assert true
+    end
+
+    it 'no coercing for application/json' do
+      e = assert_raises(Committee::InvalidRequest) {
+        operation_object.validate_request_params({'integer' => '1'}, HEADER, @validator_option)
+      }
+
+      assert_match(/expected integer, but received String: 1/i, e.message)
       assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
     end
 


### PR DESCRIPTION
To fix #286.

This disables coerece_form_params option in the case of `application/json`.
But, disabling coerce_form_params prevents coercing DateTime in object.

https://github.com/ota42y/openapi_parser/blob/d17334a866b39fa197d324b9d321df2b03d469b6/lib/openapi_parser/schema_validators/object_validator.rb#L41

I found that defining `ObjectValidator#initialize(validator, coerce_value, datetime_coerce_class)` in OpenAPIParser and adding coercing condition like below, it works. but I'm not sure this way is good or not.

```diff
-value.merge!(coerced_values.to_h) if @coerce_value
+value.merge!(coerced_values.to_h) if @coerce_value || !@datetime_coerce_class.nil?
```