### PR TITLE
Test Assertions: assert HTTP status code explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,25 +255,25 @@ describe Committee::Middleware::Stub do
   end
 
   def committee_options
-    @committee_options ||= { schema: Committee::Drivers::load_from_file('docs/schema.json'), prefix: "/v1", validate_success_only: true }
+    @committee_options ||= { schema: Committee::Drivers::load_from_file('docs/schema.json'), prefix: "/v1" }
   end
 
   describe "GET /" do
-    it "conforms to schema" do
-      assert_schema_conform
+    it "conforms to schema with 200 response code" do
+      assert_schema_conform(200)
     end
 
     it "conforms to request schema" do
       assert_request_schema_confirm
     end
 
-    it "conforms to response schema" do
-      assert_response_schema_confirm
+    it "conforms to response schema with 200 response code" do
+      assert_response_schema_confirm(200)
     end
 
-    it "conforms to response and request schema" do
+    it "conforms to response and request schema with 200 response code" do
       @committee_options[:old_assert_behavior] = false
-      assert_schema_conform
+      assert_schema_conform(200)
     end
   end
 end

--- a/test/test/methods_new_version_test.rb
+++ b/test/test/methods_new_version_test.rb
@@ -39,7 +39,7 @@ describe Committee::Test::Methods do
     it "passes through a valid response" do
       @app = new_rack_app(JSON.generate([ValidApp]))
       get "/apps"
-      assert_schema_conform
+      assert_schema_conform(200)
     end
 
     it "passes with prefix" do
@@ -47,16 +47,25 @@ describe Committee::Test::Methods do
 
       @app = new_rack_app(JSON.generate([ValidApp]))
       get "/v1/apps"
-      assert_schema_conform
+      assert_schema_conform(200)
     end
 
     it "detects an invalid response Content-Type" do
       @app = new_rack_app(JSON.generate([ValidApp]), 200, {})
       get "/apps"
       e = assert_raises(Committee::InvalidResponse) do
-        assert_schema_conform
+        assert_schema_conform(200)
       end
       assert_match(/response header must be set to/i, e.message)
+    end
+
+    it "it detects unexpected response code" do
+      @app = new_rack_app(JSON.generate([ValidApp]), 400)
+      get "/apps"
+      e = assert_raises(Committee::InvalidResponse) do
+        assert_schema_conform(200)
+      end
+      assert_match(/Expected `200` status code, but it was `400`/i, e.message)
     end
 
     it "detects an invalid response Content-Type but ignore because it's not success status code" do
@@ -70,7 +79,7 @@ describe Committee::Test::Methods do
       @app = new_rack_app(JSON.generate([ValidApp]), 400, {})
       get "/apps"
       e = assert_raises(Committee::InvalidResponse) do
-        assert_schema_conform
+        assert_schema_conform(400)
       end
       assert_match(/response header must be set to/i, e.message)
     end

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -46,14 +46,14 @@ describe Committee::Test::Methods do
       it "passes through a valid response" do
         @app = new_rack_app(JSON.generate([ValidApp]))
         get "/apps"
-        assert_schema_conform
+        assert_schema_conform(200)
       end
 
       it "detects an invalid response Content-Type" do
         @app = new_rack_app(JSON.generate([ValidApp]), {})
         get "/apps"
         e = assert_raises(Committee::InvalidResponse) do
-          assert_schema_conform
+          assert_schema_conform(200)
         end
         assert_match(/response header must be set to/i, e.message)
       end
@@ -64,7 +64,8 @@ describe Committee::Test::Methods do
         _, err = capture_io do
           assert_schema_conform
         end
-        assert_match(/\[DEPRECATION\]/i, err)
+        assert_match(/\[DEPRECATION\] Now assert_schema_conform check response schema only/i, err)
+        assert_match(/\[DEPRECATION\] Pass expected response status code/i, err)
       end
     end
 
@@ -161,7 +162,8 @@ describe Committee::Test::Methods do
         _, err = capture_io do
           assert_schema_conform
         end
-        assert_match(/\[DEPRECATION\]/i, err)
+        assert_match(/\[DEPRECATION\] Now assert_schema_conform check response schema only/i, err)
+        assert_match(/\[DEPRECATION\] Pass expected response status code/i, err)
       end
     end
 


### PR DESCRIPTION
This PR adds explicit assertion of HTTP status code instead of use of `validate_success_only` attribute.

before:

```ruby
assert_schema_conform
assert_response_schema_confirm
```

after:
```ruby
assert_schema_conform(200)
assert_response_schema_confirm(200)
```

### Context

The current implementation does not provide a way to assure that the request's preparation was successful and the response is checked against the correct scheme. The `validate_success_only` parameter partially solves this problem, but only for successful requests. However, if we want to check the error code, we will again find ourselves in a possible error situation. Explicit assertion of HTTP status code solves this issue.