### PR TITLE
use rubocop 1.12.x

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rr", "~> 1.1"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"
-  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop", "< 1.13.0"
   s.add_development_dependency "rubocop-performance"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
rubocop 1.13.0 drop ruby 2.4.x, but now committee support ruby 2.4 so uuse 1.12.x
We'll drop ruby 2.4.x next major update (5.0.0)