### PR TITLE
strict response validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Option values and defaults:
 |validate_success_only| true | false | Also validate non-2xx responses only. |
 |ignore_error| false | false | Validate and ignore result even if validation is error. So always return original data. |
 |parse_response_by_content_type| false | false | Parse response body to JSON only if Content-Type header is 'application/json'. When false, this always optimistically parses as JSON without checking for Content-Type header. |
+|strict| false | false | Puts the middleware into strict mode, meaning that response code and content type does not defined in the schema will be responded to with a 500 instead of application's status code. |
 
 No boolean option values:
 

--- a/lib/committee/middleware/response_validation.rb
+++ b/lib/committee/middleware/response_validation.rb
@@ -7,10 +7,7 @@ module Committee
 
       def initialize(app, options = {})
         super
-
-        unless options[:strict].nil?
-          Committee.warn_deprecated("Committee: Committee::Middleware::ResponseValidation doesn't support strict option now but we'll support this option. This change break backward compatibility so please remove strict option from ResponseValidation")
-        end
+        @strict = options[:strict]
         @validate_success_only = @schema.validator_option.validate_success_only
       end
 
@@ -19,7 +16,7 @@ module Committee
 
         begin
           v = build_schema_validator(request)
-          v.response_validate(status, headers, response) if v.link_exist? && self.class.validate?(status, validate_success_only)
+          v.response_validate(status, headers, response, @strict) if v.link_exist? && self.class.validate?(status, validate_success_only)
 
         rescue Committee::InvalidResponse
           handle_exception($!, request.env)

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -34,6 +34,7 @@ module Committee
           full_body
         end
 
+        # TODO: refactoring name
         strict = test_method
         Committee::SchemaValidator::OpenAPI3::ResponseValidator.
             new(@operation_object, validator_option).

--- a/test/schema_validator/open_api_3/response_validator_test.rb
+++ b/test/schema_validator/open_api_3/response_validator_test.rb
@@ -42,6 +42,15 @@ describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do
     assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
   end
 
+  it "raises InvalidResponse when a invalid status code with strict option" do
+    @status = 201
+    e = assert_raises(Committee::InvalidResponse) {
+      call_response_validator(true)
+    }
+
+    assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
+  end
+
   it "passes through a valid response with no Content-Type" do
     @headers = {}
     call_response_validator


### PR DESCRIPTION
This changes break backward compatibility because when the user set strict option, old version is ignore but this version doesn't ignore.
So we should add warning on old version.

close: https://github.com/interagent/committee/issues/317