### PR TITLE
Allow `HEAD` method in v3

### DIFF
--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -51,6 +51,8 @@ module Committee
                   validate_post_request_params(params, headers, validator_option)
                 when 'delete'
                   validate_get_request_params(params, headers, validator_option)
+                when 'head'
+                  validate_get_request_params(params, headers, validator_option)
                 else
                   raise "Committee OpenAPI3 not support #{request_operation.http_method} method"
                 end

--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -41,18 +41,10 @@ module Committee
 
         def validate_request_params(params, headers, validator_option)
           ret, err = case request_operation.http_method
-                when 'get'
+                when 'get', 'delete', 'head'
                   validate_get_request_params(params, headers, validator_option)
-                when 'post'
+                when 'post', 'put', 'patch'
                   validate_post_request_params(params, headers, validator_option)
-                when 'put'
-                  validate_post_request_params(params, headers, validator_option)
-                when 'patch'
-                  validate_post_request_params(params, headers, validator_option)
-                when 'delete'
-                  validate_get_request_params(params, headers, validator_option)
-                when 'head'
-                  validate_get_request_params(params, headers, validator_option)
                 else
                   raise "Committee OpenAPI3 not support #{request_operation.http_method} method"
                 end

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -113,6 +113,26 @@ paths:
                 properties:
                   integer:
                     type: integer
+      parameters:
+        - name: limit
+          in: query
+          description: maximum number of characters
+          required: false
+          schema:
+            type: integer
+            format: int32
+    options:
+      description: preflight request
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  integer:
+                    type: integer
 
   /string_params_coercer:
     get:

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -461,10 +461,10 @@ describe Committee::Middleware::RequestValidation do
     @app = new_rack_app(schema: open_api_3_schema)
 
     e = assert_raises(RuntimeError) {
-      head "/characters", {}
+      options "/characters", {}
     }
 
-    assert_equal 'Committee OpenAPI3 not support head method', e.message
+    assert_equal 'Committee OpenAPI3 not support options method', e.message
   end
 
   describe 'check header' do

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -155,6 +155,28 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       end
     end
 
+    describe 'support head method' do
+      before do
+        @path = '/characters'
+        @method = 'head'
+      end
+
+      it 'correct' do
+        operation_object.validate_request_params({"limit" => "1"}, HEADER, @validator_option)
+
+        assert true
+      end
+
+      it 'invalid type' do
+        e = assert_raises(Committee::InvalidRequest) {
+          operation_object.validate_request_params({"limit" => "a"}, HEADER, @validator_option)
+        }
+
+        assert_match(/expected integer, but received String: "a"/i, e.message)
+        assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
+      end
+    end
+
     describe '#content_types' do
       it 'returns supported content types' do
         @path = '/validate_content_types'


### PR DESCRIPTION
I've followed [this commit](https://github.com/interagent/committee/commit/c0fe6d47c11a83e52909e92944aa0e0a951b97dd#diff-dd6da75ddbbb89e04e9c6d6320d52a08fd7232b16a167c9b256a437ab06ee8fb) which added support for `DELETE` method.

Please take a look.