### PR TITLE
Support Psych v4.0.0

### DIFF
--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -28,7 +28,8 @@ module Committee
     # @param [String] schema_path
     # @return [Committee::Driver]
     def self.load_from_yaml(schema_path)
-      load_from_data(YAML.load_file(schema_path), schema_path)
+      data = YAML.respond_to?(:unsafe_load_file) ? YAML.unsafe_load_file(schema_path) : YAML.load_file(schema_path)
+      load_from_data(data, schema_path)
     end
 
     # load and build drive from file

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -48,6 +48,9 @@ paths:
                 properties:
                   string_1:
                     type: string
+                  time_string_1:
+                    type: string
+                    exmaple: 2021-09-22T05:36:45Z
                   array_1:
                     type: array
                     items:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -82,7 +82,11 @@ def open_api_2_form_data
 end
 
 def open_api_3_data
-  YAML.load_file(open_api_3_schema_path)
+  if YAML.respond_to?(:unsafe_load_file)
+    YAML.unsafe_load_file(open_api_3_schema_path)
+  else
+    YAML.load_file(open_api_3_schema_path)
+  end
 end
 
 def hyper_schema_schema_path


### PR DESCRIPTION
# Fixes #334

Ruby master ships with Psych 4.0.0 which makes `YAML.load_file` defaults to safe mode (https://github.com/ruby/psych/pull/487).

Keep compatibility by using `unsafe_load_file`.