### PR TITLE
Support Http OPTIONS method

### DIFF
--- a/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
+++ b/lib/committee/schema_validator/open_api_3/operation_wrapper.rb
@@ -43,7 +43,7 @@ module Committee
           ret, err = case request_operation.http_method
                 when 'get', 'delete', 'head'
                   validate_get_request_params(params, headers, validator_option)
-                when 'post', 'put', 'patch'
+                when 'post', 'put', 'patch', 'options'
                   validate_post_request_params(params, headers, validator_option)
                 else
                   raise "Committee OpenAPI3 not support #{request_operation.http_method} method"

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -394,6 +394,26 @@ paths:
                 properties:
                   string:
                     type: string
+    options:
+      description: validate options metodhd
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                integer:
+                  type: integer
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  string:
+                    type: string
 
   /validate_content_types:
     post:
@@ -565,6 +585,12 @@ paths:
         '200':
           $ref: '#/components/responses/header_integer_required'
     delete:
+      parameters:
+        - $ref: '#/components/parameters/header_integer_required'
+      responses:
+        '200':
+          $ref: '#/components/responses/header_integer_required'
+    options:
       parameters:
         - $ref: '#/components/parameters/header_integer_required'
       responses:

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -457,16 +457,6 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 204, last_response.status
   end
 
-  it "OpenAPI3 raise not support method" do
-    @app = new_rack_app(schema: open_api_3_schema)
-
-    e = assert_raises(RuntimeError) {
-      options "/characters", {}
-    }
-
-    assert_equal 'Committee OpenAPI3 not support options method', e.message
-  end
-
   describe 'check header' do
     [
       { check_header: true, description: 'valid value', value: 1, expected: { status: 200 } },
@@ -482,7 +472,7 @@ describe Committee::Middleware::RequestValidation do
       value = h[:value]
       expected = h[:expected]
       describe "when #{check_header}" do
-        %w(get post put patch delete).each do |method|
+        %w(get post put patch delete options).each do |method|
           describe method do
             describe description do
               it (expected[:error].nil? ? 'should pass' : 'should fail') do

--- a/test/middleware/response_validation_open_api_3_test.rb
+++ b/test/middleware/response_validation_open_api_3_test.rb
@@ -142,7 +142,7 @@ describe Committee::Middleware::ResponseValidation do
       header = h[:header]
       expected = h[:expected]
       describe "when #{check_header}" do
-        %w(get post put patch delete).each do |method|
+        %w(get post put patch delete options).each do |method|
           describe method do
             describe description do
               if expected[:error].nil?

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -177,6 +177,19 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       end
     end
 
+    it 'support options method' do
+      @method = "options"
+      operation_object.validate_request_params({"integer" => 1}, HEADER, @validator_option)
+
+      e = assert_raises(Committee::InvalidRequest) {
+        operation_object.validate_request_params({"integer" => "str"}, HEADER, @validator_option)
+      }
+
+      assert_match(/expected integer, but received String: "str"/i, e.message)
+      assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
+    end
+
+
     describe '#content_types' do
       it 'returns supported content types' do
         @path = '/validate_content_types'


### PR DESCRIPTION
https://github.com/interagent/committee/pull/340 added support for `HEAD` requests.
This PR adds support for `OPTIONS` requests.