### PR TITLE
Accept callable :error_class in middleware options.

### DIFF
--- a/lib/committee/middleware/base.rb
+++ b/lib/committee/middleware/base.rb
@@ -7,6 +7,7 @@ module Committee
         @app = app
 
         @error_class = options.fetch(:error_class, Committee::ValidationError)
+        @error_class = @error_class.call if @error_class.respond_to?(:call)
         @error_handler = options[:error_handler]
         @ignore_error = options.fetch(:ignore_error, false)
 


### PR DESCRIPTION
This fix allows autoloadable constants to be passed as `:error_class`.

Rails 7 doesn't "enable" constants autoload while running application.rb and initializers,
and so during middlewares initialization it's simply impossible to access any constant
from the `app` directory. By wrapping it with lambda we can lazy-load error_class.