### PR TITLE
Introduce section in the README to list tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,3 +503,7 @@ bundle exec ruby -Ilib -Itest test/router_test.rb -n /prefix/
     ```
     bundle exec rake release
     ```
+
+## Tutorials
+
+- [Validating requests and responses using OpenAPI specification with Committee](https://nicolasiensen.github.io/2022-04-18-validating-requests-and-responses-using-openapi-specification-with-committee/)


### PR DESCRIPTION
In this commit, we are introducing a new section in the README file to list tutorials on how to use Committee.

I included a blog post I have recently published where I show how to eliminate duplication between specification and implementation in Ruby projects using Committee.