### PR TITLE
Use `media_type` instead of `content_type` to suppress content-type warning

### DIFF
--- a/lib/committee/schema_validator.rb
+++ b/lib/committee/schema_validator.rb
@@ -4,7 +4,7 @@ module Committee
   module SchemaValidator
     class << self
       def request_media_type(request)
-        request.content_type.to_s.split(";").first.to_s
+        request.media_type.to_s.split(";").first.to_s
       end
 
       # @param [String] prefix

--- a/lib/committee/schema_validator/hyper_schema/response_validator.rb
+++ b/lib/committee/schema_validator/hyper_schema/response_validator.rb
@@ -48,7 +48,7 @@ module Committee
         private
 
         def response_media_type(response)
-          response.content_type.to_s.split(";").first.to_s
+          response.media_type.to_s.split(";").first.to_s
         end
 
         def check_content_type!(response)


### PR DESCRIPTION
## Issue

closes https://github.com/interagent/committee/issues/359

## Change

As [deprecation warning](https://github.com/rails/rails/blob/40272988cec849c734ec02cfa89ff830ae019d9e/actionpack/lib/action_dispatch/http/mime_negotiation.rb#L38-L41) below says, if just MIME type is necessary, it should use `media_type`.

```
DEPRECATION WARNING: Rails 7.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead.
```

So this pull request just replaces `content_type` with `media_type`.

`ActionDispatch::(Request|Response)#media_type` seem to exist since Rails 3.x ([ref](https://apidock.com/rails/ActionDispatch/Request/media_type)), I believe it's okay to just replace.