### PR TITLE
update latest version for rack-test

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "openapi_parser", "1.0.0.beta1"
 
   s.add_development_dependency "minitest", "~> 5.3"
-  s.add_development_dependency "rack-test", "~> 0.6"
+  s.add_development_dependency "rack-test", "~> 0.8"
   s.add_development_dependency "rake", "~> 12.3"
   s.add_development_dependency "rr", "~> 1.1"
   s.add_development_dependency "pry"


### PR DESCRIPTION
We use custom_request for test but this method doesn't exist 0.6.3 so we should update this