### PR TITLE
Rename `parameter_overwite_by_rails_rule` to `parameter_overwrite_by_rails_rule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Rename `parameter_overwite_by_rails_rule` to `parameter_overwrite_by_rails_rule` #396
 
 ## [5.2.0] - 2024-05-04
 - Error explicitly that OpenAPI 3.1+ isn't supported #418

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Important changes are also described below.
 Committee 5.* has few breaking changes so we recommend upgrading to the latest release on 4.* and fixing any deprecation errors you see before upgrading.
 
 - set `parse_response_by_content_type=true` by default (old versions set `false`)
-- set `parameter_overwite_by_rails_rule=true` by default (old version set `false`)
+- set `parameter_overwrite_by_rails_rule=true` by default (old version set `false`)
 
 #### Future Updates (5.*~)
 OpenAPI3 Schema Users: Newly-added `strict_reference_validation` option defaults to `false` if not set.

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -97,7 +97,7 @@ module Committee
       end
 
       def copy_coerced_data_to_params(request)
-        order = if validator_option.parameter_overwite_by_rails_rule
+        order = if validator_option.parameter_overwrite_by_rails_rule
           # (high priority) path_hash_key -> query_param -> request_body_hash          
           [validator_option.request_body_hash_key, validator_option.query_hash_key, validator_option.path_hash_key]
         else

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -45,7 +45,14 @@ module Committee
         @coerce_recursive                 = options.fetch(:coerce_recursive, true)
         @optimistic_json                  = options.fetch(:optimistic_json, false)
         @parse_response_by_content_type   = options.fetch(:parse_response_by_content_type, true)
-        @parameter_overwrite_by_rails_rule = options.fetch(:parameter_overwrite_by_rails_rule, true)
+
+        @parameter_overwrite_by_rails_rule =
+          if options.key?(:parameter_overwite_by_rails_rule)
+            Committee.warn_deprecated_until_6(true, "The option `parameter_overwite_by_rails_rule` is deprecated. Use `parameter_overwrite_by_rails_rule` instead.")
+            options[:parameter_overwite_by_rails_rule]
+          else
+            options.fetch(:parameter_overwrite_by_rails_rule, true)
+          end
 
         # Boolean options and have a different value by default
         @allow_get_body        = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -17,7 +17,7 @@ module Committee
                   :optimistic_json,
                   :validate_success_only,
                   :parse_response_by_content_type,
-                  :parameter_overwite_by_rails_rule
+                  :parameter_overwrite_by_rails_rule
 
       # Non-boolean options:
       attr_reader :headers_key,
@@ -45,7 +45,7 @@ module Committee
         @coerce_recursive                 = options.fetch(:coerce_recursive, true)
         @optimistic_json                  = options.fetch(:optimistic_json, false)
         @parse_response_by_content_type   = options.fetch(:parse_response_by_content_type, true)
-        @parameter_overwite_by_rails_rule = options.fetch(:parameter_overwite_by_rails_rule, true)
+        @parameter_overwrite_by_rails_rule = options.fetch(:parameter_overwrite_by_rails_rule, true)
 
         # Boolean options and have a different value by default
         @allow_get_body        = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -419,7 +419,7 @@ describe Committee::Middleware::RequestValidation do
         assert_equal env['committee.query_hash']['integer'], 42
         #assert_equal env['rack.request.query_hash'][:integer], 42 # this isn't hash indifferent hash because we use rack.request.query_hash
         [204, {}, []]
-      end, schema: open_api_3_schema, parameter_overwite_by_rails_rule: false)
+      end, schema: open_api_3_schema, parameter_overwrite_by_rails_rule: false)
 
       header "Content-Type", "application/json"
       post '/overwrite_same_parameter?integer=42'
@@ -434,7 +434,7 @@ describe Committee::Middleware::RequestValidation do
         assert_equal env['committee.request_body_hash'][:integer], 21
         assert_equal env['committee.query_hash']['integer'], 42
         [204, {}, []]
-      end, schema: open_api_3_schema, parameter_overwite_by_rails_rule: false)
+      end, schema: open_api_3_schema, parameter_overwrite_by_rails_rule: false)
 
       params = {integer: 21}
 
@@ -454,7 +454,7 @@ describe Committee::Middleware::RequestValidation do
         assert_equal env['committee.query_hash']['integer'], 84 # we can't use query_parameter :(
         #assert_equal env['rack.request.query_hash'][:integer], 21 # this isn't hash indifferent hash because we use rack.request.query_hash
         [204, {}, []]
-      end, schema: open_api_3_schema, parameter_overwite_by_rails_rule: false)
+      end, schema: open_api_3_schema, parameter_overwrite_by_rails_rule: false)
 
       params = {integer: 21}
 


### PR DESCRIPTION
"overwite" is probably a typo for "overwrite" ?

- https://github.com/interagent/committee/pull/374