### PR TITLE
Bump openapi_parser dependency to 2.0

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json_schema", "~> 0.14", ">= 0.14.3"
 
   s.add_dependency "rack", ">= 1.5"
-  s.add_dependency "openapi_parser", "~> 1.0"
+  s.add_dependency "openapi_parser", "~> 2.0"
 
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rack-test", "~> 0.8"


### PR DESCRIPTION
v2.0 of openapi_parser has a [very useful fix to support nullable anyOf, allOf, oneOf types](https://github.com/ota42y/openapi_parser/pull/128). This is a common way to handle nullable references.