### PR TITLE
Run CI workflow on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,15 @@
 name: ci
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
         ruby:
           - "2.6"
           - "2.7"
@@ -15,9 +17,9 @@ jobs:
           - "3.1"
           - "3.2"
           - ruby-head
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
I noticed that CI only runs when you push to master, not on pull requests. I also took the liberty of removing the macos runner, it seemed a bit unnecessary since there isn't anything platform specific in this library (I can add it back in if I'm missing something).