### PR TITLE
CI against Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
           - ruby-head
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Committee is tested on the following MRI versions:
 - 3.0
 - 3.1
 - 3.2
+- 3.3
 
 ## Committee::Middleware::RequestValidation
 


### PR DESCRIPTION
This PR adds Ruby 3.3 to CI matrix