### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A collection of middleware to help build services with JSON Schema, OpenAPI 2, O
 
 Committee is tested on the following MRI versions:
 
-- 2.6
 - 2.7
 - 3.0
 - 3.1


### PR DESCRIPTION
Drop support for Ruby 2.6. 2.6 has been out of support for almost two
years now (Mar 2022), and is causing a few issues with upgrading
dependencies [1], so it's probably okay at this point for Committee to
drop support for it.

[1] https://github.com/interagent/committee/pull/400