### PR TITLE
Add base64 to gemspec

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rack", ">= 1.5"
   s.add_dependency "openapi_parser", "~> 2.0"
+  s.add_dependency 'base64'
 
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rack-test", "~> 0.8"


### PR DESCRIPTION
base64 is loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. https://github.com/interagent/committee/actions/runs/7624721002/job/20767482497?pr=404#step:4:5