### PR TITLE
Organize and update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true
+  SuggestExtensions: false
   Exclude:
     - 'examples/**/*'
     - 'vendor/**/*'

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -33,7 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rubocop"
   s.add_development_dependency "rubocop-performance"
-  s.add_development_dependency "rubocop-minitest"
-  s.add_development_dependency "rubocop-rake"
   s.add_development_dependency "simplecov"
 end

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rr", "~> 1.1"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"
-  s.add_development_dependency "rubocop", "< 1.13.0"
+  s.add_development_dependency "rubocop"
   s.add_development_dependency "rubocop-performance"
   s.add_development_dependency "rubocop-minitest"
   s.add_development_dependency "rubocop-rake"


### PR DESCRIPTION
RuboCop was fixed to an older version due to supporting Ruby 2.4 at that time. However, it currently supports versions 2.7 and above, so the version constraint has been removed. Additionally, unused and unnecessary extensions were removed, suppressing the following warnings.


```
❯ bundle exec rubocop
Inspecting 81 files
.................................................................................

81 files inspected, no offenses detected

The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-minitest
  * rubocop-rake
```

base64 is loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. 
Although rubocop so far depends on base64, rubocop has not been added to the runtime dependency so far. So, rubocop will not work on Ruby heads with rubocop prior to [v1.56.0](https://github.com/rubocop/rubocop/releases/tag/v1.56.0). So it is a good to keep the version up to date.

https://github.com/interagent/committee/actions/runs/7624721002/job/20767482497?pr=404#step:4:5