### PR TITLE
Enable `Layout/ExtraSpacing`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ AllCops:
     - 'examples/**/*'
     - 'vendor/**/*'
 
+Layout/ExtraSpacing:
+  Enabled: true
+
 Performance:
   Exclude:
     - 'test/**/*'

--- a/lib/committee.rb
+++ b/lib/committee.rb
@@ -22,7 +22,7 @@ module Committee
   end
 
   def self.warn_deprecated_until_6(cond, message)
-    raise "remove deprecated!"  unless Committee::VERSION.start_with?("5")
+    raise "remove deprecated!" unless Committee::VERSION.start_with?("5")
     warn("[DEPRECATION] #{message}") if cond
   end
 end

--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -6,7 +6,7 @@ module Committee
       def initialize(app, options={})
         super
 
-        @strict  = options[:strict]
+        @strict = options[:strict]
       end
 
       def handle(request)

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -32,7 +32,7 @@ module Committee
         @headers_key         = options[:headers_key]    || "committee.headers"
         @params_key          = options[:params_key]     || "committee.params"
         @query_hash_key      = options[:query_hash_key] || "committee.query_hash"
-        @path_hash_key      = options[:path_hash_key] || "committee.path_hash"
+        @path_hash_key = options[:path_hash_key] || "committee.path_hash"
         @request_body_hash_key = options[:request_body_hash_key] || "committee.request_body_hash"
 
         @prefix              = options[:prefix]

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -29,30 +29,30 @@ module Committee
 
       def initialize(options, schema, schema_type)
         # Non-boolean options
-        @headers_key         = options[:headers_key]    || "committee.headers"
-        @params_key          = options[:params_key]     || "committee.params"
-        @query_hash_key      = options[:query_hash_key] || "committee.query_hash"
-        @path_hash_key = options[:path_hash_key] || "committee.path_hash"
+        @headers_key           = options[:headers_key]    || "committee.headers"
+        @params_key            = options[:params_key]     || "committee.params"
+        @query_hash_key        = options[:query_hash_key] || "committee.query_hash"
+        @path_hash_key         = options[:path_hash_key] || "committee.path_hash"
         @request_body_hash_key = options[:request_body_hash_key] || "committee.request_body_hash"
 
-        @prefix              = options[:prefix]
+        @prefix                = options[:prefix]
 
         # Boolean options and have a common value by default
-        @allow_form_params   = options.fetch(:allow_form_params, true)
-        @allow_query_params  = options.fetch(:allow_query_params, true)
-        @check_content_type  = options.fetch(:check_content_type, true)
-        @check_header        = options.fetch(:check_header, true)
-        @coerce_recursive    = options.fetch(:coerce_recursive, true)
-        @optimistic_json     = options.fetch(:optimistic_json, false)
-        @parse_response_by_content_type = options.fetch(:parse_response_by_content_type, true)
+        @allow_form_params                = options.fetch(:allow_form_params, true)
+        @allow_query_params               = options.fetch(:allow_query_params, true)
+        @check_content_type               = options.fetch(:check_content_type, true)
+        @check_header                     = options.fetch(:check_header, true)
+        @coerce_recursive                 = options.fetch(:coerce_recursive, true)
+        @optimistic_json                  = options.fetch(:optimistic_json, false)
+        @parse_response_by_content_type   = options.fetch(:parse_response_by_content_type, true)
         @parameter_overwite_by_rails_rule = options.fetch(:parameter_overwite_by_rails_rule, true)
 
         # Boolean options and have a different value by default
-        @allow_get_body      = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)
-        @coerce_date_times   = options.fetch(:coerce_date_times, schema.driver.default_coerce_date_times)
-        @coerce_form_params  = options.fetch(:coerce_form_params, schema.driver.default_coerce_form_params)
-        @coerce_path_params  = options.fetch(:coerce_path_params, schema.driver.default_path_params)
-        @coerce_query_params = options.fetch(:coerce_query_params, schema.driver.default_query_params)
+        @allow_get_body        = options.fetch(:allow_get_body, schema.driver.default_allow_get_body)
+        @coerce_date_times     = options.fetch(:coerce_date_times, schema.driver.default_coerce_date_times)
+        @coerce_form_params    = options.fetch(:coerce_form_params, schema.driver.default_coerce_form_params)
+        @coerce_path_params    = options.fetch(:coerce_path_params, schema.driver.default_path_params)
+        @coerce_query_params   = options.fetch(:coerce_query_params, schema.driver.default_query_params)
         @validate_success_only = options.fetch(:validate_success_only, schema.driver.default_validate_success_only)
       end
     end


### PR DESCRIPTION
Since it only removes extra spaces and does not involve any destructive changes, I believe it should be fine. What do you think?

```
❯ bundle exec rubocop -A
....C.....................C................C.....................................

Offenses:

lib/committee.rb:25:31: C: [Corrected] Layout/ExtraSpacing: Unnecessary spacing detected.
    raise "remove deprecated!"  unless Committee::VERSION.start_with?("5")
                              ^
lib/committee/middleware/request_validation.rb:9:16: C: [Corrected] Layout/ExtraSpacing: Unnecessary spacing detected.
        @strict  = options[:strict]
               ^
lib/committee/schema_validator/option.rb:35:23: C: [Corrected] Layout/ExtraSpacing: Unnecessary spacing detected.
        @path_hash_key      = options[:path_hash_key] || "committee.path_hash"
                      ^^^^^

81 files inspected, 3 offenses detected, 3 offenses corrected
```