### PR TITLE
Use `Object#stub` instead of rr

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rack-test", "~> 0.8"
   s.add_development_dependency "rake", "~> 12.3"
-  s.add_development_dependency "rr", "~> 1.1"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rubocop"

--- a/test/committee_test.rb
+++ b/test/committee_test.rb
@@ -19,13 +19,15 @@ describe Committee do
     old_stderr = $stderr
     $stderr = StringIO.new
     begin
-      stub(Committee).debug? { false }
-      Committee.log_debug "blah"
-      assert_equal "", $stderr.string
+      Committee.stub(:debug?, false) do
+        Committee.log_debug "blah"
+        assert_equal "", $stderr.string
+      end
 
-      stub(Committee).debug? { true }
-      Committee.log_debug "blah"
-      assert_equal "blah\n", $stderr.string
+      Committee.stub(:debug?, true) do
+        Committee.log_debug "blah"
+        assert_equal "blah\n", $stderr.string
+      end
     ensure
       $stderr = old_stderr
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,6 @@ require "minitest"
 require "minitest/spec"
 require "minitest/autorun"
 require "rack/test"
-require "rr"
 require "pry"
 require "stringio"
 


### PR DESCRIPTION
Since the [last commit for rr is in 2022](https://github.com/rr/rr/commits/master/), and currently, only the `stub` feature of rr is being used in committee, I believe it is possible to replace this with [Object#stub](https://www.rubydoc.info/gems/minitest/5.3.0/Object:stub) provided by Minitest. In general, I think it's better to minimize dependencies. WDYT?