### PR TITLE
Bump rake from 12.3 to 13.1

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rack-test", "~> 0.8"
-  s.add_development_dependency "rake", "~> 12.3"
+  s.add_development_dependency "rake", "~> 13.1"
   s.add_development_dependency "rr", "~> 1.1"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This PR has been updated to the latest rake at this time. https://rubygems.org/gems/rack-test/versions/2.1.0