### PR TITLE
Change the year of the license to the first publication date only

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2018 [CONTRIBUTORS.md](https://github.com/interagent/committee/blob/master/CONTRIBUTORS.md)
+Copyright (c) 2013 [CONTRIBUTORS.md](https://github.com/interagent/committee/blob/master/CONTRIBUTORS.md)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
This PR change the year of the license to the first publication date only.

>DO YOU CHANGE THE YEARS STATED ON YOUR BLOG AND WEBSITE?
>
>Use the earliest date of publication. For example, if you first published on your blog in 2012, when you amend the blog content or add to it, continue to use the 2012 date or use a range of dates such as 2012–2022.

https://www.copyrightlaws.com/copyright-symbol-notice-year/