### PR TITLE
Raise error when loading OpenAPI 3.1 schema

### DIFF
--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -70,6 +70,10 @@ module Committee
         return Committee::Drivers::OpenAPI3::Driver.new.parse(openapi)
       end
 
+      if hash['openapi']&.start_with?('3.1.')
+        raise OpenAPI3Unsupported.new('Committee does not support OpenAPI 3.1 yet')
+      end
+
       driver = if hash['swagger'] == '2.0'
                  Committee::Drivers::OpenAPI2::Driver.new
                else

--- a/test/data/openapi3/3_1.yaml
+++ b/test/data/openapi3/3_1.yaml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: OpenAPI 3.1 Test
+  description: A Sample file
+paths:
+  /characters:
+    get:
+      description: get characters
+      parameters:
+      - name: school_name
+        in: query
+        description: school name to filter by
+        required: false
+        style: form
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -48,6 +48,13 @@ describe Committee::Drivers do
       assert_kind_of Committee::Drivers::OpenAPI3::Schema, s
     end
 
+    it 'fails to load OpenAPI 3.1' do
+      e = assert_raises(Committee::OpenAPI3Unsupported) do
+        Committee::Drivers.load_from_file(open_api_3_1_schema_path, parser_options:{strict_reference_validation: true})
+      end
+      assert_equal 'Committee does not support OpenAPI 3.1 yet', e.message
+    end
+
     it 'fails to load OpenAPI 3 with invalid reference' do
       parser_options = { strict_reference_validation: true }
       assert_raises(OpenAPIParser::MissingReferenceError) do
@@ -137,6 +144,13 @@ describe Committee::Drivers do
       s = Committee::Drivers.load_from_data(hyper_schema_data)
       assert_kind_of Committee::Drivers::Schema, s
       assert_kind_of Committee::Drivers::HyperSchema::Schema, s
+    end
+
+    it 'fails to load OpenAPI 3.1' do
+      e = assert_raises(Committee::OpenAPI3Unsupported) do
+        Committee::Drivers.load_from_data(open_api_3_1_data)
+      end
+      assert_equal 'Committee does not support OpenAPI 3.1 yet', e.message
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -90,6 +90,14 @@ def open_api_3_data
   end
 end
 
+def open_api_3_1_data
+  if YAML.respond_to?(:unsafe_load_file)
+    YAML.unsafe_load_file(open_api_3_1_schema_path)
+  else
+    YAML.load_file(open_api_3_1_schema_path)
+  end
+end
+
 def hyper_schema_schema_path
   "./test/data/hyperschema/paas.json"
 end
@@ -112,6 +120,10 @@ end
 
 def open_api_3_0_1_schema_path
   "./test/data/openapi3/3_0_1.yaml"
+end
+
+def open_api_3_1_schema_path
+  "./test/data/openapi3/3_1.yaml"
 end
 
 def open_api_3_invalid_reference_path


### PR DESCRIPTION
Hi! Thank you for maintaining this great gem.
It can be confusing when the HyperSchema driver is used while loading the OpenAPI 3.1 schema. I think it would be beneficial to raise an error until OpenAPI 3.1 is officially supported.

https://github.com/interagent/committee/issues/303

> I just found a problem when I upgrade OpenAPI version in document to 3.1.0.
The current implementation has locked version to 3.0.x, and fails finding paths for this document.
> Current behaviour:
> - runs HyperSchema driver for version OpenAPI version 3.x.x