### PR TITLE
Error on anything above OpenAPI 3.1 as well + changelog

### DIFF
--- a/lib/committee/drivers.rb
+++ b/lib/committee/drivers.rb
@@ -70,8 +70,10 @@ module Committee
         return Committee::Drivers::OpenAPI3::Driver.new.parse(openapi)
       end
 
-      if hash['openapi']&.start_with?('3.1.')
-        raise OpenAPI3Unsupported.new('Committee does not support OpenAPI 3.1 yet')
+      if (version = hash['openapi'])
+        if Gem::Version.new(version) >= Gem::Version.new("3.1")
+          raise OpenAPI3Unsupported.new('Committee does not support OpenAPI 3.1+ yet')
+        end
       end
 
       driver = if hash['swagger'] == '2.0'

--- a/test/drivers_test.rb
+++ b/test/drivers_test.rb
@@ -48,11 +48,11 @@ describe Committee::Drivers do
       assert_kind_of Committee::Drivers::OpenAPI3::Schema, s
     end
 
-    it 'fails to load OpenAPI 3.1' do
+    it 'fails to load OpenAPI 3.1+' do
       e = assert_raises(Committee::OpenAPI3Unsupported) do
         Committee::Drivers.load_from_file(open_api_3_1_schema_path, parser_options:{strict_reference_validation: true})
       end
-      assert_equal 'Committee does not support OpenAPI 3.1 yet', e.message
+      assert_equal 'Committee does not support OpenAPI 3.1+ yet', e.message
     end
 
     it 'fails to load OpenAPI 3 with invalid reference' do
@@ -146,11 +146,11 @@ describe Committee::Drivers do
       assert_kind_of Committee::Drivers::HyperSchema::Schema, s
     end
 
-    it 'fails to load OpenAPI 3.1' do
+    it 'fails to load OpenAPI 3.1+' do
       e = assert_raises(Committee::OpenAPI3Unsupported) do
         Committee::Drivers.load_from_data(open_api_3_1_data)
       end
-      assert_equal 'Committee does not support OpenAPI 3.1 yet', e.message
+      assert_equal 'Committee does not support OpenAPI 3.1+ yet', e.message
     end
   end
 end


### PR DESCRIPTION
Follows up #418 with a small future compatibility change so that if an
OpenAPI version is anything equal or greater than 3.1 the error is
produced. Also, add a changelog entry about it.