### PR TITLE
Ensure body is rewound

### DIFF
--- a/committee.gemspec
+++ b/committee.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "openapi_parser", "~> 2.0"
 
   s.add_development_dependency "minitest", "~> 5.3"
-  s.add_development_dependency "rack-test", "~> 0.8"
+  s.add_development_dependency "rack-test"
   s.add_development_dependency "rake", "~> 13.1"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"

--- a/committee.gemspec
+++ b/committee.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "json_schema", "~> 0.14", ">= 0.14.3"
 
-  s.add_dependency "rack", ">= 1.5"
+  s.add_dependency "rack", ">= 1.5", "< 3.1"
   s.add_dependency "openapi_parser", "~> 2.0"
 
   s.add_development_dependency "minitest", "~> 5.3"

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -46,7 +46,11 @@ module Committee
       if @allow_form_params && %w[application/x-www-form-urlencoded multipart/form-data].include?(request.media_type)
         # Actually, POST means anything in the request body, could be from
         # PUT or PATCH too. Silly Rack.
-        return [request.POST, true] if request.POST
+        begin
+          return [request.POST, true] if request.POST
+        ensure
+          request.body.rewind
+        end
       end
 
       [{}, false]


### PR DESCRIPTION
This is a small change to always rewind the request body. `Rack::Request#POST` no longer does this in recent Rack versions. It was removed in rack/rack@42aff22f708123839ba706cbe659d108b47c40c7.

`Rack::RewindableInput::Middleware` is likely going to be required for most users of this library.

Committee requires more changes to be compatible with Rack 3.1.x. I'm adding a constraint so Bundler doesn't try to upgrade dependencies past what's supported.