### PR TITLE
invoke error_handler on Committee::NotFound

### DIFF
--- a/lib/committee/middleware/request_validation.rb
+++ b/lib/committee/middleware/request_validation.rb
@@ -20,6 +20,7 @@ module Committee
           raise if @raise
           return @error_class.new(400, :bad_request, $!.message, request).render unless @ignore_error
         rescue Committee::NotFound => e
+          handle_exception($!, request.env)
           raise if @raise
           return @error_class.new(404, :not_found, e.message, request).render unless @ignore_error
         rescue JSON::ParserError


### PR DESCRIPTION
My rationale is that an exception is raised if `raise` is true, but there is no opportunity to handle this error differently if otherwise.