### PR TITLE
Check Content-Type header for OPTIONS requests

### DIFF
--- a/lib/committee/schema_validator/open_api_3/request_validator.rb
+++ b/lib/committee/schema_validator/open_api_3/request_validator.rb
@@ -21,8 +21,8 @@ module Committee
         private
 
         def check_content_type(request, content_type)
-          # support post, put, patch only
-          return true unless request.post? || request.put? || request.patch?
+          # support post, put, patch, options only
+          return true unless request.post? || request.put? || request.patch? || request.options?
           return true if @operation_object.valid_request_content_type?(content_type)
           return true if @operation_object.optional_body? && empty_request?(request)
 

--- a/test/schema_validator/open_api_3/request_validator_test.rb
+++ b/test/schema_validator/open_api_3/request_validator_test.rb
@@ -95,6 +95,13 @@ describe Committee::SchemaValidator::OpenAPI3::RequestValidator do
       assert_equal 400, last_response.status
     end    
 
+    it "validates content_type for option request" do
+      @app = new_rack_app(check_content_type: true, schema: open_api_3_schema)
+      header "Content-Type", "text/html"
+      options "/validate", "{}"
+      assert_equal 400, last_response.status
+    end
+
     def new_rack_app(options = {})
       Rack::Builder.new {
         use Committee::Middleware::RequestValidation, options


### PR DESCRIPTION
We encountered a problem when a client made an `OPTIONS` request, because committee does only validate the content type header for `POST`, `PUT` and `PATCH` requests.

The OpenAPI (3) schema for the endpoint looks like this:

```yaml
MySchema:
  type: object
  required:
  - document_id
  properties:
    document_id:
      type: integer
```

The client left out the `Content-Type` header and sent and empty request body which did not lead to an `Committee::InvalidRequest` error.