### PR TITLE
Support multiple response schemas for OpenAPI 2

### DIFF
--- a/lib/committee/drivers/open_api_2/driver.rb
+++ b/lib/committee/drivers/open_api_2/driver.rb
@@ -91,18 +91,18 @@ module Committee
 
         def find_best_fit_response(link_data)
           if response_data = link_data["responses"]["200"] || response_data = link_data["responses"][200]
-            [200, response_data]
+            200
           elsif response_data = link_data["responses"]["201"] || response_data = link_data["responses"][201]
-            [201, response_data]
+            201
           else
             # Sort responses so that we can try to prefer any 3-digit status code.
             # If there are none, we'll just take anything from the list.
             ordered_responses = link_data["responses"].
               select { |k, v| k.to_s =~ /[0-9]{3}/ }
             if first = ordered_responses.first
-              [first[0].to_i, first[1]]
+              first[0].to_i
             else
-              [nil, nil]
+              nil
             end
           end
         end
@@ -174,18 +174,15 @@ module Committee
                 schemas_data["properties"][href]["properties"][method] = schema_data
               end
 
-              # Arbitrarily pick one response for the time being. Prefers in order:
-              # a 200, 201, any 3-digit numerical response, then anything at all.
-              status, response_data = find_best_fit_response(link_data)
-              if status
-                link.status_success = status
+              target_schemas_data["properties"][href]["properties"][method] ||= {"properties"=> {}}
+              link_data["responses"].each do |key, response_data|
+                status = key.to_i
+                next unless response_data["schema"]
 
-                # A link need not necessarily specify a target schema.
-                if response_data["schema"]
-                  target_schemas_data["properties"][href]["properties"][method] =
-                    response_data["schema"]
-                end
+                target_schemas_data["properties"][href]["properties"][method]["properties"][status] = response_data["schema"]
               end
+
+              link.status_success = find_best_fit_response(link_data)
 
               rx = %r{^#{href_to_regex(link.href)}$}
               Committee.log_debug "Created route: #{link.method} #{link.href} (regex #{rx})"
@@ -218,8 +215,10 @@ module Committee
               end
 
               # response
-              link.target_schema =
-                target_schemas.properties[link.href].properties[method]
+              link.target_schemas = {}
+              target_schemas.properties[link.href].properties[method].properties.each do |status, schema|
+                link.target_schemas[status] = schema
+              end
             end
           end
 

--- a/lib/committee/drivers/open_api_2/link.rb
+++ b/lib/committee/drivers/open_api_2/link.rb
@@ -23,12 +23,19 @@ module Committee
 
         # The link's output schema. i.e. How we validate an endpoint's response
         # data.
-        attr_accessor :target_schema
+        attr_accessor :target_schemas
 
         attr_accessor :header_schema
 
         def rel
           raise "Committee: rel not implemented for OpenAPI"
+        end
+
+        def target_schema
+          target_schemas[status_success] ||
+            target_schemas[200] ||
+            target_schemas[201] ||
+            target_schemas.values.first
         end
       end
     end

--- a/test/drivers/open_api_2/link_test.rb
+++ b/test/drivers/open_api_2/link_test.rb
@@ -11,7 +11,7 @@ describe Committee::Drivers::OpenAPI2::Link do
     @link.method = "GET"
     @link.status_success = 200
     @link.schema = { "title" => "input" }
-    @link.target_schema = { "title" => "target" }
+    @link.target_schemas = {200 => { "title" => "target" }}
   end
 
   it "uses set #enc_type" do

--- a/test/schema_validator/hyper_schema/response_generator_test.rb
+++ b/test/schema_validator/hyper_schema/response_generator_test.rb
@@ -74,52 +74,57 @@ describe Committee::SchemaValidator::HyperSchema::ResponseGenerator do
 
   it "generates first enum value for a schema with enum" do
     link = Committee::Drivers::OpenAPI2::Link.new
-    link.target_schema = JsonSchema::Schema.new
-    link.target_schema.enum = ["foo"]
-    link.target_schema.type = ["string"]
+    target_schema = JsonSchema::Schema.new
+    target_schema.enum = ["foo"]
+    target_schema.type = ["string"]
+    link.target_schemas = {200 => target_schema}
     data, _schema = Committee::SchemaValidator::HyperSchema::ResponseGenerator.new.call(link)
     assert_equal("foo", data)
   end
 
   it "generates basic types" do
     link = Committee::Drivers::OpenAPI2::Link.new
-    link.target_schema = JsonSchema::Schema.new
+    target_schema = JsonSchema::Schema.new
+    link.target_schemas = {200 => target_schema}
 
-    link.target_schema.type = ["integer"]
+    target_schema.type = ["integer"]
     data, _schema = Committee::SchemaValidator::HyperSchema::ResponseGenerator.new.call(link)
     assert_equal 0, data
 
-    link.target_schema.type = ["null"]
+    target_schema.type = ["null"]
     data, _schema = Committee::SchemaValidator::HyperSchema::ResponseGenerator.new.call(link)
     assert_nil data
 
-    link.target_schema.type = ["string"]
+    target_schema.type = ["string"]
     data, _schema = Committee::SchemaValidator::HyperSchema::ResponseGenerator.new.call(link)
     assert_equal "", data
   end
 
   it "generates an empty array for an array type" do
     link = Committee::Drivers::OpenAPI2::Link.new
-    link.target_schema = JsonSchema::Schema.new
-    link.target_schema.type = ["array"]
+    target_schema = JsonSchema::Schema.new
+    link.target_schemas = {200 => target_schema}
+    target_schema.type = ["array"]
     data, _schema = Committee::SchemaValidator::HyperSchema::ResponseGenerator.new.call(link)
     assert_equal([], data)
   end
 
   it "generates an empty object for an object with no fields" do
     link = Committee::Drivers::OpenAPI2::Link.new
-    link.target_schema = JsonSchema::Schema.new
-    link.target_schema.type = ["object"]
+    target_schema = JsonSchema::Schema.new
+    link.target_schemas = {200 => target_schema}
+    target_schema.type = ["object"]
     data, _schema = Committee::SchemaValidator::HyperSchema::ResponseGenerator.new.call(link)
     assert_equal({}, data)
   end
 
   it "prefers an example to a built-in value" do
     link = Committee::Drivers::OpenAPI2::Link.new
-    link.target_schema = JsonSchema::Schema.new
+    target_schema = JsonSchema::Schema.new
+    link.target_schemas = {200 => target_schema}
 
-    link.target_schema.data = { "example" => 123 }
-    link.target_schema.type = ["integer"]
+    target_schema.data = { "example" => 123 }
+    target_schema.type = ["integer"]
 
     data, _schema = Committee::SchemaValidator::HyperSchema::ResponseGenerator.new.call(link)
     assert_equal 123, data
@@ -127,9 +132,10 @@ describe Committee::SchemaValidator::HyperSchema::ResponseGenerator do
 
   it "prefers non-null types to null types" do
     link = Committee::Drivers::OpenAPI2::Link.new
-    link.target_schema = JsonSchema::Schema.new
+    target_schema = JsonSchema::Schema.new
+    link.target_schemas = {200 => target_schema}
 
-    link.target_schema.type = ["null", "integer"]
+    target_schema.type = ["null", "integer"]
     data, _schema = Committee::SchemaValidator::HyperSchema::ResponseGenerator.new.call(link)
     assert_equal 0, data
   end


### PR DESCRIPTION
Hi!

I noticed while testing OpenAPI3 vs OpenAPI2 that if a response was missing in the OpenAPI definition, then the OpenAPI2 driver would fail silently.

It's not the case for OpenAPI 3, where it says that the status code one tried to validate is not defined.

I feel that this might be a breaking change (since this will raise an error, where before it was working without problems), but I still think it's worth checking with you if you think it's a change worth merging into committee.

Let me know if you this makes sense or if you'd like me to change something!