### PR TITLE
Add CodeSpell workflow for spell checking in pull requests

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,15 @@
+name: CodeSpell
+on:
+  - pull_request
+jobs:
+  codespell:
+    name: CodeSpell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: CodeSpell
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          ignore_words_file: .codespellignore
+          exclude_file: examples/openapi3_rails/config/storage.yml,test/data/openapi2/petstore-expanded.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.99.0.beta1] - 2023-01-24
 - We add backport parameter overwrite rule [#373](https://github.com/interagent/committee/pull/373)
   - We provide merged parameter for `committee.params` ( `params_key` option)
-  - When a same parameter name exist in path/query/request body, it overwritten.
+  - When a parameter of the same name exists in the path/query/request body, it will be overwritten.
   - We we change overwrite rule next version.
   - Please set `parameter_overwite_by_rails_rule=true` for Rails rule (v5.0.0)
     - (high priority) path_hash_key -> request_body_hash -> query_param

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.99.0.beta1] - 2023-01-24
 - We add backport parameter overwrite rule [#373](https://github.com/interagent/committee/pull/373)
   - We provide merged parameter for `committee.params` ( `params_key` option)
-  - When a same parameter name exist in path/query/request body, it overwrited.
+  - When a same parameter name exist in path/query/request body, it overwritten.
   - We we change overwrite rule next version.
   - Please set `parameter_overwite_by_rails_rule=true` for Rails rule (v5.0.0)
     - (high priority) path_hash_key -> request_body_hash -> query_param


### PR DESCRIPTION
We would like to leave it to codespell to verify the spelling of our code.
I propose to use codespell-project/actions-codespell, now v2.1.

https://github.com/codespell-project/actions-codespell