### PR TITLE
Fix a warning no department given for SpaceInsideHashLiteralBraces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,7 +110,7 @@ Layout/SpaceInsideArrayPercentLiteral:
 Layout/SpaceInsideBlockBraces:
   Enabled: true
 
-SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
 
 Layout/SpaceInsideParens:


### PR DESCRIPTION
```
Warning: no department given for SpaceInsideHashLiteralBraces.
```