### PR TITLE
Add Ruby 3.4 to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
           - ruby-head
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Committee is tested on the following MRI versions:
 - 3.1
 - 3.2
 - 3.3
+- 3.4
 
 ## Committee::Middleware::RequestValidation
 


### PR DESCRIPTION
Ruby 3.4 has been released🎉
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/