### PR TITLE
Parse JSON when lower-case content-type is given

### DIFF
--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -29,7 +29,8 @@ module Committee
         data = {}
         unless full_body.empty?
           parse_to_json = !validator_option.parse_response_by_content_type ||
-                          headers.fetch('Content-Type', nil)&.start_with?('application/json')
+                          headers.fetch('Content-Type', nil)&.start_with?('application/json') ||
+                          headers.fetch('content-type', nil)&.start_with?('application/json')
           data = JSON.parse(full_body) if parse_to_json
         end
 

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -27,9 +27,10 @@ module Committee
         end
 
         parse_to_json = !validator_option.parse_response_by_content_type ||
-                        headers.fetch('Content-Type', nil)&.start_with?('application/json')
+                        headers.fetch('Content-Type', nil)&.start_with?('application/json') ||
+                        headers.fetch('content-type', nil)&.start_with?('application/json')
         data = if parse_to_json
-                 full_body.empty? ? {} : JSON.parse(full_body)
+          full_body.empty? ? {} : JSON.parse(full_body)
         else
           full_body
         end

--- a/test/middleware/response_validation_open_api_3_test.rb
+++ b/test/middleware/response_validation_open_api_3_test.rb
@@ -17,6 +17,22 @@ describe Committee::Middleware::ResponseValidation do
     assert_equal 200, last_response.status
   end
 
+  it "passes through a valid response with content-type (lower-case)" do
+    status = 200
+    headers = { "content-type" => "application/json" }
+    response = JSON.generate(CHARACTERS_RESPONSE)
+
+    @app = Rack::Builder.new {
+      use Committee::Middleware::ResponseValidation, {schema: open_api_3_schema}
+      run lambda { |_|
+        [status, headers, [response]]
+      }
+    }
+
+    get "/characters"
+    assert_equal 200, last_response.status
+  end
+
   it "passes through a invalid json" do
     @app = new_response_rack("not_json", {}, schema: open_api_3_schema)
 

--- a/test/middleware/response_validation_test.rb
+++ b/test/middleware/response_validation_test.rb
@@ -15,6 +15,23 @@ describe Committee::Middleware::ResponseValidation do
     assert_equal 200, last_response.status
   end
 
+  it "passes through a valid response with content-type (lower-case)" do
+    options = { schema: hyper_schema }
+    status = 200
+    headers = { 'content-type' => 'application/json' }
+    response = JSON.generate([ValidApp])
+    @app = Rack::Builder.new {
+      use Committee::Middleware::ResponseValidation, options
+      run lambda { |_|
+        [status, headers, [response]]
+      }
+    }
+
+    get "/apps"
+    puts(last_response.body)
+    assert_equal 200, last_response.status
+  end
+
   it "doesn't call error_handler (has a arg) when response is valid" do
     called = false
     pr = ->(_e) { called = true }


### PR DESCRIPTION
Thank you for your nice gem to make our application robust.
I would like to fix a small problem.

## Problem to be solved

committee doesn't parse the response when `content-type: application/json` header is given.
Then, the validation failed due to comparing an object and String.

```json
{
    "id":"invalid_response",
    "message":"#/paths/~1characters/get/responses/200/content/application~1json/schema expected object, but received String: \"{\\\"Otonokizaka\\\":[\\\"Honoka.Kousaka\\\"]}\""
}
```

## How to solve it

Parse also the response when `content-type: application/json`.

## References

- [Are HTTP headers case-sensitive? - Stack Overflow](https://stackoverflow.com/a/5259004)
  - > Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.
- [rack/SPEC.rdoc at v3.1.9 · rack/rack](https://github.com/rack/rack/blob/v3.1.9/SPEC.rdoc#the-headers-)
  - > Header keys must not contain uppercase ASCII characters (A-Z)
- https://github.com/ota42y/openapi_parser/pull/178#issuecomment-2494440535
  - This comment also refers to the same problem.