### PR TITLE
Add option to allow all GET and non-GET params in validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This piece of middleware validates the parameters of incoming requests to make s
 |allow_form_params | true | true | Specifies that input can alternatively be specified as `application/x-www-form-urlencoded` parameters when possible. This won't work for more complex schema validations. |
 |allow_get_body | true | false | Allow GET request body, which merge to request parameter. See (#211) |
 |allow_query_params | true | true | Specifies that query string parameters will be taken into consideration when doing validation. |
+|allow_non_get_query_params | false | false | Allow GET and non-GET query string parameters to be taken into consideration when doing validation. |
 |check_content_type | true | true | Specifies that `Content-Type` should be verified according to JSON Hyper-schema or OpenAPI 3 definition. |
 |check_header | true | true | Check header data using JSON Hyper-schema or OpenAPI 3 definition. |
 |coerce_date_times | false | true | Convert the string with `"format": "date-time"` parameter to DateTime object. |

--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -21,10 +21,11 @@ module Committee
     end
 
     def initialize(options = {})
-      @allow_form_params  = options[:allow_form_params]
-      @allow_get_body     = options[:allow_get_body]
-      @allow_query_params = options[:allow_query_params]
-      @optimistic_json    = options[:optimistic_json]
+      @allow_form_params          = options[:allow_form_params]
+      @allow_get_body             = options[:allow_get_body]
+      @allow_query_params         = options[:allow_query_params]
+      @allow_non_get_query_params = options[:allow_non_get_query_params]
+      @optimistic_json            = options[:optimistic_json]
     end
 
     # return params and is_form_params
@@ -57,7 +58,15 @@ module Committee
     end
 
     def unpack_query_params(request)
-      @allow_query_params ? self.class.indifferent_params(request.GET) : {}
+      unless @allow_query_params
+        return {}
+      end
+
+      if @allow_non_get_query_params
+        self.class.indifferent_params(request.params)
+      else
+        self.class.indifferent_params(request.GET)
+      end
     end
 
     def unpack_headers(request)

--- a/lib/committee/schema_validator/hyper_schema.rb
+++ b/lib/committee/schema_validator/hyper_schema.rb
@@ -66,6 +66,7 @@ module Committee
           allow_form_params:  validator_option.allow_form_params,
           allow_get_body:     validator_option.allow_get_body,
           allow_query_params: validator_option.allow_query_params,
+          allow_non_get_query_params: validator_option.allow_non_get_query_params,
           optimistic_json:    validator_option.optimistic_json,
         )
 

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -87,6 +87,7 @@ module Committee
           allow_form_params:  validator_option.allow_form_params,
           allow_get_body:     validator_option.allow_get_body,
           allow_query_params: validator_option.allow_query_params,
+          allow_non_get_query_params: validator_option.allow_non_get_query_params,
           optimistic_json:    validator_option.optimistic_json,
         )
 

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -8,6 +8,7 @@ module Committee
                   :allow_form_params,
                   :allow_get_body,
                   :allow_query_params,
+                  :allow_non_get_query_params,
                   :check_content_type,
                   :check_header,
                   :coerce_date_times,
@@ -37,6 +38,7 @@ module Committee
         @allow_blank_structures           = options.fetch(:allow_blank_structures, false)
         @allow_form_params                = options.fetch(:allow_form_params, true)
         @allow_query_params               = options.fetch(:allow_query_params, true)
+        @allow_non_get_query_params       = options.fetch(:allow_non_get_query_params, false)
         @check_content_type               = options.fetch(:check_content_type, true)
         @check_header                     = options.fetch(:check_header, true)
         @coerce_recursive                 = options.fetch(:coerce_recursive, true)

--- a/test/request_unpacker_test.rb
+++ b/test/request_unpacker_test.rb
@@ -99,6 +99,13 @@ describe Committee::RequestUnpacker do
     assert_equal({ "a" => "b" }, unpacker.unpack_query_params(request))
   end
 
+  it "unpacks query params from non-get requests with allow_non_get_query_params" do
+    env = { "rack.input" => StringIO.new(""), "REQUEST_METHOD" => "PUT", "QUERY_STRING" => "a=b" }
+    request = Rack::Request.new(env)
+    unpacker = Committee::RequestUnpacker.new({ allow_query_params: true, allow_non_get_query_params: true })
+    assert_equal({ "a" => "b" }, unpacker.unpack_query_params(request))
+  end
+
   it "errors if JSON is not an object" do
     env = { "CONTENT_TYPE" => "application/json", "rack.input" => StringIO.new('[2]'), }
     request = Rack::Request.new(env)


### PR DESCRIPTION
Fixes #412

This adds config to allow including all parameters when validating schema for GET and non-GET requests, disabled by default.

I understand the desire to only support query params for GET requests, but this behavior was working before, and our application depends on that behavior. So rather than rewriting those APIs, I think it's reasonable to have an option to support the existing behavior for legacy applications.

/cc @ydah 