### PR TITLE
Add option to allow empty date and date-time strings

### DIFF
--- a/lib/committee/request_unpacker.rb
+++ b/lib/committee/request_unpacker.rb
@@ -21,11 +21,12 @@ module Committee
     end
 
     def initialize(options = {})
-      @allow_form_params          = options[:allow_form_params]
-      @allow_get_body             = options[:allow_get_body]
-      @allow_query_params         = options[:allow_query_params]
-      @allow_non_get_query_params = options[:allow_non_get_query_params]
-      @optimistic_json            = options[:optimistic_json]
+      @allow_empty_date_and_datetime = options[:allow_empty_date_and_datetime]
+      @allow_form_params             = options[:allow_form_params]
+      @allow_get_body                = options[:allow_get_body]
+      @allow_query_params            = options[:allow_query_params]
+      @allow_non_get_query_params    = options[:allow_non_get_query_params]
+      @optimistic_json               = options[:optimistic_json]
     end
 
     # return params and is_form_params

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -84,6 +84,7 @@ module Committee
 
       def request_unpack(request)
         unpacker = Committee::RequestUnpacker.new(
+          allow_empty_date_and_datetime: validator_option.allow_empty_date_and_datetime,
           allow_form_params:  validator_option.allow_form_params,
           allow_get_body:     validator_option.allow_get_body,
           allow_query_params: validator_option.allow_query_params,

--- a/lib/committee/schema_validator/open_api_3/response_validator.rb
+++ b/lib/committee/schema_validator/open_api_3/response_validator.rb
@@ -12,12 +12,15 @@ module Committee
           @operation_wrapper = operation_wrapper
           @validate_success_only = validator_option.validate_success_only
           @check_header = validator_option.check_header
+          @allow_empty_date_and_datetime = validator_option.allow_empty_date_and_datetime
         end
 
         def call(status, headers, response_data, strict)
           return unless Committee::Middleware::ResponseValidation.validate?(status, validate_success_only)
 
-          operation_wrapper.validate_response_params(status, headers, response_data, strict, check_header)
+          validator_options = { allow_empty_date_and_datetime: @allow_empty_date_and_datetime }
+
+          operation_wrapper.validate_response_params(status, headers, response_data, strict, check_header, validator_options: validator_options)
         end
 
         private

--- a/lib/committee/schema_validator/option.rb
+++ b/lib/committee/schema_validator/option.rb
@@ -5,6 +5,7 @@ module Committee
     class Option
       # Boolean Options
       attr_reader :allow_blank_structures,
+                  :allow_empty_date_and_datetime,
                   :allow_form_params,
                   :allow_get_body,
                   :allow_query_params,
@@ -36,6 +37,7 @@ module Committee
 
         # Boolean options and have a common value by default
         @allow_blank_structures           = options.fetch(:allow_blank_structures, false)
+        @allow_empty_date_and_datetime    = options.fetch(:allow_empty_date_and_datetime, false)
         @allow_form_params                = options.fetch(:allow_form_params, true)
         @allow_query_params               = options.fetch(:allow_query_params, true)
         @allow_non_get_query_params       = options.fetch(:allow_non_get_query_params, false)

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -205,6 +205,12 @@ paths:
         schema:
           type: string
           format: date-time
+      - name: date_string
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date
       - name: normal_array
         in: query
         description: number data
@@ -683,7 +689,7 @@ paths:
         in: query
         required: false
         schema:
-          type: integer    
+          type: integer
       requestBody:
         content:
           application/json:
@@ -721,6 +727,26 @@ paths:
       responses:
         '204':
           description: sample of remote schema reference
+
+  /date_time:
+    get:
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  date:
+                    type: string
+                    format: date
+                  date-time:
+                    type: string
+                    format: date-time
+              example:
+                date: 2020-05-12
+                date-time: 2020-05-12T00:00:00.00Z
 
 components:
   schemas:

--- a/test/schema_validator/open_api_3/response_validator_test.rb
+++ b/test/schema_validator/open_api_3/response_validator_test.rb
@@ -75,6 +75,76 @@ describe Committee::SchemaValidator::OpenAPI3::ResponseValidator do
     call_response_validator
   end
 
+  describe 'allow_empty_date_and_datetime' do
+    it "errors given an empty date string with allow_empty_date_and_datetime disabled" do
+      @path = '/date_time'
+      @method = 'get'
+      @data = { 'date' => '' }
+
+      e = assert_raises(Committee::InvalidResponse) {
+        call_response_validator
+      }
+      assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
+      assert_match(/\"\" is not conformant with date format/i, e.message)
+    end
+
+    it "errors given an empty date-time string with allow_empty_date_and_datetime disabled" do
+      @path = '/date_time'
+      @method = 'get'
+      @data = { 'date-time' => '' }
+
+      e = assert_raises(Committee::InvalidResponse) {
+        call_response_validator
+      }
+      assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
+      assert_match(/\"\" is not conformant with date-time format/i, e.message)
+    end
+
+    it "passes given an empty date string with allow_empty_date_and_datetime enabled" do
+      @validator_option = Committee::SchemaValidator::Option.new(
+        { allow_empty_date_and_datetime: true },
+        open_api_3_schema,
+        :open_api_3)
+
+      @path = '/date_time'
+      @method = 'get'
+      @data = { 'date' => '' }
+
+      if OpenAPIParser::VERSION >= "2.2.6"
+        response = call_response_validator
+        assert_equal({ 'date' => '' }, response)
+      else
+        e = assert_raises(Committee::InvalidResponse) {
+          call_response_validator
+        }
+        assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
+        assert_match(/\"\" is not conformant with date format/i, e.message)
+      end
+    end
+
+    it "passes given an empty date-time string with allow_empty_date_and_datetime enabled" do
+      @validator_option = Committee::SchemaValidator::Option.new(
+        { allow_empty_date_and_datetime: true },
+        open_api_3_schema,
+        :open_api_3)
+
+      @path = '/date_time'
+      @method = 'get'
+      @data = { 'date-time' => '' }
+
+      if OpenAPIParser::VERSION >= "2.2.6"
+        response = call_response_validator
+        assert_equal({ 'date-time' => '' }, response)
+      else
+        e = assert_raises(Committee::InvalidResponse) {
+          call_response_validator
+        }
+        assert_kind_of(OpenAPIParser::OpenAPIError, e.original_error)
+        assert_match(/\"\" is not conformant with date-time format/i, e.message)
+      end
+    end
+  end
+
   private
 
   def call_response_validator(strict = false)


### PR DESCRIPTION
Depends on ota42y/openapi_parser#182.

I wasn't sure how to version guard this, but the tests pass using my branch. But this won't work without a version of openapi_parser which includes that option.

I chose to test the validation error message, but there weren't other examples like this in the code base so maybe unnecessary (testing the parser, not the tool). More just me making sure things were lined up properly.