### PR TITLE
Supports streaming response validation via `streaming_content_parsers` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ use Committee::Middleware::ResponseValidation,
 
 This allows you to validate streaming response formats by providing custom parsers for specific content types. The parser lambda receives the complete response body as a string and should return the parsed data for validation.
 
+**Note:** This feature uses `Rack::BodyProxy` internally, which buffers the entire response body in memory before validation. This can consume significant memory for large streaming responses. Consider this limitation when validating large data streams.
+
 Limitation: For standard Content-Types, it is possible to intervene in the actual response when validation fails (e.g., by setting the HTTP status code to 500). However, for Content-Types specified via the `streaming_content_parsers` option, validation is performed only after the entire response body has been read—that is, after it has already been returned to the client—making it impossible to modify the response. In such cases, only `handle_exception` is called, and an error is raised if necessary.
 
 ## Using OpenAPI 3

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ No boolean option values:
 |prefix| String | support | support | Mounts the middleware to respond at a configured prefix. |
 |error_class| StandardError | support | support | Specifies the class to use for formatting and outputting validation errors (defaults to `Committee::ValidationError`). |
 |error_handler| Proc Object | support | support | A proc which will be called when error occurs. Take an Error instance as first argument, and request.env as second argument. (e.g. `-> (ex, env) { Raven.capture_exception(ex, extra: { rack_env: env }) }`) |
+|streaming_content_parsers| Hash[String, Proc] | support | support | A hash mapping content types to custom parser lambdas for streaming responses (e.g. `{ 'text/event-stream' => ->(body) { body } }`). Used for validating streaming response formats like Server-Sent Events. |
 
 Given a simple Sinatra app that responds for an endpoint in an incomplete fashion:
 
@@ -318,6 +319,23 @@ use Committee::Middleware::RequestValidation,
 Committee has few options which enable convert request data.
 By default committee save converted data to `committee.params` and rails does not read it.
 So we need to save converted value to `'action_dispatch.request.request_parameters'` because rails create parameter from this value.
+
+### Streaming Response Validation
+
+Committee supports validating streaming responses like Server-Sent Events or custom streaming formats using the `streaming_content_parsers` option:
+
+```ruby
+use Committee::Middleware::ResponseValidation,
+  schema_path: 'docs/schema.json',
+  streaming_content_parsers: {
+    'text/event-stream' => ->(body) { body },  # Pass through SSE as string
+    'application/x-json-stream' => ->(body) { JSON.parse(body) }  # Parse custom JSON stream
+  }
+```
+
+This allows you to validate streaming response formats by providing custom parsers for specific content types. The parser lambda receives the complete response body as a string and should return the parsed data for validation.
+
+Limitation: For standard Content-Types, it is possible to intervene in the actual response when validation fails (e.g., by setting the HTTP status code to 500). However, for Content-Types specified via the `streaming_content_parsers` option, validation is performed only after the entire response body has been read—that is, after it has already been returned to the client—making it impossible to modify the response. In such cases, only `handle_exception` is called, and an error is raised if necessary.
 
 ## Using OpenAPI 3
 

--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -20,7 +20,7 @@ module Committee
         copy_coerced_data_to_params(request)
       end
 
-      def response_validate(status, headers, response, test_method = false)
+      def response_validate(status, headers, response, test_method = false, custom_body_parser = nil)
         full_body = +""
         response.each do |chunk|
           full_body << chunk
@@ -33,7 +33,9 @@ module Committee
                           true
                         end
 
-        data = if parse_to_json
+        data = if custom_body_parser
+                 custom_body_parser.call(full_body)
+               elsif parse_to_json
                  full_body.empty? ? {} : JSON.parse(full_body)
                else
                  full_body

--- a/test/data/openapi3/streaming_response.yaml
+++ b/test/data/openapi3/streaming_response.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Server-Sent Events API
+  description: API demonstrating Server-Sent Events with text/event-stream
+paths:
+  /events/stream:
+    get:
+      description: Stream real-time events
+      responses:
+        "200":
+          description: Event stream established successfully
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: |
+                  Server-Sent Events stream. Each event follows the SSE format:
+
+                  data: Hello
+
+                  data: World
+  /events/stream/json:
+    get:
+      description: Stream real-time events in JSON format
+      responses:
+        "200":
+          description: Event stream established successfully
+          content:
+            application/x-json-stream:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    description: The event ID
+                  message:
+                    type: string
+                    description: The event message
+                required:
+                  - id
+                  - message

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,6 +61,10 @@ def open_api_3_coverage_schema
   @open_api_3_coverage_schema ||= Committee::Drivers.load_from_file(open_api_3_coverage_schema_path, parser_options: { strict_reference_validation: true })
 end
 
+def open_api_3_streaming_response_schema
+  @open_api_3_streaming_response_schema ||= Committee::Drivers.load_from_file(open_api_3_streaming_response_schema_path, parser_options: { strict_reference_validation: true })
+end
+
 # Don't cache this because we'll often manipulate the created hash in tests.
 def hyper_schema_data
   JSON.parse(File.read(hyper_schema_schema_path))
@@ -121,4 +125,8 @@ end
 
 def open_api_3_invalid_reference_path
   "./test/data/openapi3/invalid_reference.yaml"
+end
+
+def open_api_3_streaming_response_schema_path
+  "./test/data/openapi3/streaming_response.yaml"
 end


### PR DESCRIPTION
## Background

In the existing implementation, when the response body of streaming events such as Server-Sent Events passes through `Committee::Middleware::ResponseValidation`, the `response_validate` method from [OpenAPI 3](https://github.com/interagent/committee/blob/cf8c0f268ec0c67117461aca3c9cd2fca8549b03/lib/committee/schema_validator/open_api_3.rb#L24-L27) (or [HyperSchema](https://github.com/interagent/committee/blob/cf8c0f268ec0c67117461aca3c9cd2fca8549b03/lib/committee/schema_validator/hyper_schema.rb#L24-L27)) blocks until the entire body is read. As a result, it was not possible to return responses as streams.

As a workaround for this issue, the one of the solutions is to use a middleware wrapper like the below to completely skip validation for the corresponding endpoint.

```ruby
class ConditionalCommitteeResponseValidator
  def initialize(app, options = {})
    @app = app
    @middleware = Committee::Middleware::ResponseValidation.new(app, options)
  end

  def call(env)
    path_info = env['PATH_INFO']

    return @app.call(env) if path_info == '/events/stream'

    @middleware.call(env)
  end
end
```

## Features Added by This Patch

This patch adds an option called `streaming_content_parsers` to `Committee::Middleware::ResponseValidation`. This option accepts a hash where the key is a Content-Type and the value is a Proc that receives and transforms the response body of that Content-Type.

Content-Types specified via this option bypass the normal path (which waits for the entire body to be read) and instead go through a path via `Rack::BodyProxy`. This allows the response to be streamed to the client without blocking, while still enabling validation to be performed on the transformed body via the Proc once the response body is closed.

### Usage Example

```ruby
use Committee::Middleware::ResponseValidation,
  schema_path: 'docs/schema.json',
  streaming_content_parsers: {
    'text/event-stream' => ->(body) { body },  # Pass through SSE as string
    'application/x-json-stream' => ->(body) { JSON.parse(body) }  # Parse custom JSON stream
  }
```

### Limitations

For limitations of this feature, please refer to the README.