### PR TITLE
Replace 'require' with 'plugins' in .rubocop.yml to configure RuboCop plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:


### PR DESCRIPTION
```
❯ bundle exec rake
Running RuboCop...
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /Users/ydah/committee/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```