### PR TITLE
feat(schema-validator): return to lenient status parsing for hyperschema

### DIFF
--- a/test/schema_validator/hyper_schema/response_validator_test.rb
+++ b/test/schema_validator/hyper_schema/response_validator_test.rb
@@ -9,6 +9,8 @@ describe Committee::SchemaValidator::HyperSchema::ResponseValidator do
     @data = ValidApp.dup
     @schema = JsonSchema.parse!(hyper_schema_data)
     @schema.expand_references!
+    # POST /apps
+    @create_link = @schema.properties["app"].links[0]
     # GET /apps/:id
     @get_link = @link = @schema.properties["app"].links[2]
     # GET /apps
@@ -38,6 +40,12 @@ describe Committee::SchemaValidator::HyperSchema::ResponseValidator do
 
   it "passes through a 304 Not Modified response" do
     @status, @headers, @data = 304, {}, nil
+    call
+  end
+
+  it "allows non-201 on create" do
+    @link = @create_link
+    @status = 200
     call
   end
 


### PR DESCRIPTION
- #433 added strict checking for OpenAPI2, which broke hyperschema
- this maintains strict checking for OpenAPI2 while reverting hyperschema behavior change

fixes #452
