### PR TITLE
Increment Minitest assertion count in assert_schema_conform methods

### DIFF
--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -94,6 +94,9 @@ module Committee
 
       private
 
+      # assert_*_schema_confirm signal failure by raising, not via `assert`,
+      # so Minitest would report "Test is missing assertions" on success.
+      # Bump the counter explicitly; no-op outside Minitest (e.g. RSpec).
       def increment_assertion_count
         assert true if respond_to?(:assertions)
       end

--- a/lib/committee/test/methods.rb
+++ b/lib/committee/test/methods.rb
@@ -23,6 +23,8 @@ module Committee
             schema_validator.request_validate(request_object)
           end
         end
+
+        increment_assertion_count
       end
 
       def assert_response_schema_confirm(expected_status = nil)
@@ -46,6 +48,8 @@ module Committee
         end
 
         schema_validator.response_validate(status, headers, [body], true) if validate_response?(status)
+
+        increment_assertion_count
       end
 
       def committee_options
@@ -89,6 +93,10 @@ module Committee
       end
 
       private
+
+      def increment_assertion_count
+        assert true if respond_to?(:assertions)
+      end
 
       # Temporarily adds dummy values for excepted parameters during validation
       # @see ExceptParameter

--- a/test/test/methods_test.rb
+++ b/test/test/methods_test.rb
@@ -151,6 +151,14 @@ describe Committee::Test::Methods do
         assert_request_schema_confirm
       end
 
+      it "increments the Minitest assertion count on success" do
+        @app = new_rack_app
+        get "/characters"
+        before_count = assertions
+        assert_request_schema_confirm
+        assert_equal before_count + 1, assertions
+      end
+
       it "not exist required" do
         @app = new_rack_app
         get "/validate", { "query_string" => "query", "query_integer_list" => [1, 2] }
@@ -395,6 +403,14 @@ describe Committee::Test::Methods do
         @app = new_rack_app(JSON.generate(@correct_response))
         get "/characters"
         assert_response_schema_confirm(200)
+      end
+
+      it "increments the Minitest assertion count on success" do
+        @app = new_rack_app(JSON.generate(@correct_response))
+        get "/characters"
+        before_count = assertions
+        assert_response_schema_confirm(200)
+        assert_equal before_count + 1, assertions
       end
 
       it "detects an invalid response Content-Type" do


### PR DESCRIPTION
## Summary

- `assert_request_schema_confirm` and `assert_response_schema_confirm` did not call Minitest's `assert`, so they were not counted as assertions. This caused Minitest to emit "Test is missing assertions" warnings when these were the only assertions in a test.
- Added `assert true` after successful validation to increment the assertion counter, guarded by `respond_to?(:assertions)` so it is a no-op in non-Minitest environments (e.g. RSpec).

## Test plan

- [x] Existing tests pass (`test/test/methods_test.rb`, `test/test/methods_new_version_test.rb`)
- [ ] Verify in a Minitest project that the warning no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)