### PR TITLE
docs: Add documentation to ApplicationController

### DIFF
--- a/examples/openapi3_rails/app/controllers/application_controller.rb
+++ b/examples/openapi3_rails/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+# ApplicationController serves as the base class for all API controllers in the OpenAPI3 Rails example.
+# It provides common functionality and inherits from ActionController::API for API-specific handling.
 class ApplicationController < ActionController::API
 end


### PR DESCRIPTION
### 问题背景
在 interagent/committee 仓库的 OpenAPI3 Rails 示例中，`ApplicationController` 类缺少文档说明，这使其用途和职责难以理解。作为示例代码，清晰的文档有助于用户学习和理解如何使用 Committee middleware。

### 修改内容
- **修改了什么**：在 `examples/openapi3_rails/app/controllers/application_controller.rb` 文件中，为 `ApplicationController` 类添加了类级文档注释。
- **为什么这样改**：提供清晰的描述，说明该类是所有 API 控制器的基类，并从 `ActionController::API` 继承以提供 API 特定处理。这提升了代码的可读性和可维护性，符合仓库的文档标准。
- **对代码质量/性能/安全性的提升**：仅文档改进，无功能性变化，不会影响性能或安全性。代码质量通过更易理解的示例得到提升。

### 验证方式
- 由于此修改仅添加注释，没有改变任何功能性代码，所有现有测试应继续通过。
- 进行了手动检查以确保注释准确描述了类的目的，并与仓库现有文档风格一致。
- 无需添加新测试，因为无行为变化。

### 其他信息
- 无 breaking changes。
- 此修改本身就是文档更新，无需额外文档更改。
- 无已知限制。