### PR TITLE
Expose the matched operation on SchemaValidator::OpenAPI3

### DIFF
--- a/lib/committee/schema_validator/open_api_3.rb
+++ b/lib/committee/schema_validator/open_api_3.rb
@@ -50,6 +50,10 @@ module Committee
         !@operation_object.nil?
       end
 
+      # Expose the operation matched for the request, or nil if none matched
+      # @return [Committee::SchemaValidator::OpenAPI3::OperationWrapper, nil]
+      attr_reader :operation_object
+
       private
 
       attr_reader :validator_option

--- a/test/schema_validator/open_api_3_test.rb
+++ b/test/schema_validator/open_api_3_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Committee::SchemaValidator::OpenAPI3 do
+  before do
+    @router = open_api_3_schema.build_router(schema: open_api_3_schema)
+  end
+
+  def validator_for(path, method)
+    request = Rack::Request.new({ "REQUEST_METHOD" => method, "PATH_INFO" => path, "rack.input" => StringIO.new("") })
+    @router.build_schema_validator(request)
+  end
+
+  describe "#operation_object" do
+    it "returns the matched operation wrapper" do
+      operation_object = validator_for("/validate", "POST").operation_object
+
+      assert_kind_of Committee::SchemaValidator::OpenAPI3::OperationWrapper, operation_object
+      assert_equal "/validate", operation_object.original_path
+    end
+
+    it "returns nil when the request matches no operation" do
+      assert_nil validator_for("/no-such-path", "GET").operation_object
+    end
+  end
+end


### PR DESCRIPTION
The OpenAPI 3 schema validator matches the request to an operation and holds it in `@operation_object`, but offers no public reader, so applications that want the matched operation have to use `instance_variable_get`.

One concrete use case: recording HTTP request metrics labeled by the matched `original_path` template, which keeps the label set bounded by the schema's paths instead of raw request paths (see ubicloud/ubicloud#6271, where a committee maintainer asked us to get a supported API here rather than read the ivar).

This adds a documented `attr_reader :operation_object` (returns the `OperationWrapper`, or nil when nothing matched) plus a test.