### PR TITLE
Validate OpenAPI 2 responses against status-specific schemas

### DIFF
--- a/lib/committee/schema_validator/hyper_schema/response_validator.rb
+++ b/lib/committee/schema_validator/hyper_schema/response_validator.rb
@@ -15,7 +15,7 @@ module Committee
           @validators = {}
           if link.is_a? Drivers::OpenAPI2::Link
             link.target_schemas.each do |status, schema|
-              @validators[status] = JsonSchema::Validator.new(target_schema(link))
+              @validators[status] = JsonSchema::Validator.new(schema)
             end
           else
             @validator = JsonSchema::Validator.new(target_schema(link))

--- a/test/schema_validator/hyper_schema/response_validator_test.rb
+++ b/test/schema_validator/hyper_schema/response_validator_test.rb
@@ -112,6 +112,22 @@ describe Committee::SchemaValidator::HyperSchema::ResponseValidator do
     assert_equal message, e.message
   end
 
+  it "validates OpenAPI 2 responses against the schema for their status" do
+    link = Committee::Drivers::OpenAPI2::Link.new
+    link.href = "/apps"
+    link.media_type = "application/json"
+    link.status_success = 200
+    success_schema = JsonSchema.parse!({ "type" => "object", "required" => ["id"], "properties" => { "id" => { "type" => "integer" } } })
+    error_schema = JsonSchema.parse!({ "type" => "object", "required" => ["error"], "properties" => { "error" => { "type" => "string" } } })
+    link.target_schemas = { 200 => success_schema, 400 => error_schema }
+    validator = Committee::SchemaValidator::HyperSchema::ResponseValidator.new(link, validate_success_only: false)
+
+    validator.call(200, @headers, { "id" => 1 })
+    validator.call(400, @headers, { "error" => "invalid request" })
+    assert_raises(Committee::InvalidResponse) { validator.call(200, @headers, { "error" => "invalid request" }) }
+    assert_raises(Committee::InvalidResponse) { validator.call(400, @headers, { "id" => 1, "error" => 1 }) }
+  end
+
   private
 
   def call


### PR DESCRIPTION
OpenAPI 2 response validation creates a validator for each response status, but initializes every validator with `link.target_schema`. Because that method selects a preferred success schema, responses for statuses such as 400 are also validated against the success schema.

Initialize each validator with the schema associated with its status in `link.target_schemas`.